### PR TITLE
In-memory caching for endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,11 @@ install :
 test :
 	go test ./...
 
+.PHONY : bench
+bench: export APIARY_LOGGING=false
+bench :
+	go test ./... -run=^$$ -bench=.
+
 .PHONY : vuln
 vuln : 
 	govulncheck ./...

--- a/bom-bills.go
+++ b/bom-bills.go
@@ -55,7 +55,7 @@ func (s *Server) BillsHandler() http.HandlerFunc {
 		w.end_day,
 		w.end_month,
 		y.year,
-		y.split_year,
+		w.split_year,
 		w.week_no,
 		b.week_id
 	FROM
@@ -95,7 +95,7 @@ func (s *Server) BillsHandler() http.HandlerFunc {
 		w.end_day,
 		w.end_month,
 		y.year,
-		y.split_year,
+		w.split_year,
 		w.week_no,
 		b.week_id
 	FROM
@@ -134,7 +134,7 @@ func (s *Server) BillsHandler() http.HandlerFunc {
 		w.end_day,
 		w.end_month,
 		y.year,
-		y.split_year,
+		w.split_year,
 		w.week_no,
 		b.week_id
 	FROM
@@ -173,7 +173,7 @@ func (s *Server) BillsHandler() http.HandlerFunc {
 		w.end_day,
 		w.end_month,
 		y.year,
-		y.split_year,
+		w.split_year,
 		w.week_no,
 		b.week_id
 	FROM
@@ -211,7 +211,7 @@ func (s *Server) BillsHandler() http.HandlerFunc {
 		w.end_day,
 		w.end_month,
 		y.year,
-		y.split_year,
+		w.split_year,
 		w.week_no,
 		b.week_id
 	FROM
@@ -247,7 +247,7 @@ func (s *Server) BillsHandler() http.HandlerFunc {
 		w.end_day,
 		w.end_month,
 		y.year,
-		y.split_year,
+		w.split_year,
 		w.week_no,
 		b.week_id
 	FROM
@@ -282,7 +282,7 @@ func (s *Server) BillsHandler() http.HandlerFunc {
 		w.end_day,
 		w.end_month,
 		y.year,
-		y.split_year,
+		w.split_year,
 		w.week_no,
 		b.week_id
 	FROM
@@ -317,7 +317,7 @@ func (s *Server) BillsHandler() http.HandlerFunc {
 		w.end_day,
 		w.end_month,
 		y.year,
-		y.split_year,
+		w.split_year,
 		w.week_no,
 		b.week_id
 	FROM

--- a/bom-causes.go
+++ b/bom-causes.go
@@ -48,7 +48,7 @@ func (s *Server) DeathCausesHandler() http.HandlerFunc {
 		w.end_day, 
 		w.end_month, 
 		y.year,
-		y.split_year
+		w.split_year
 	FROM 
 		bom.causes_of_death c
 	JOIN 
@@ -82,7 +82,7 @@ func (s *Server) DeathCausesHandler() http.HandlerFunc {
 		w.end_day, 
 		w.end_month, 
 		y.year,
-		y.split_year
+		w.split_year
 	FROM 
 		bom.causes_of_death c
 	JOIN 

--- a/cache-test.go
+++ b/cache-test.go
@@ -1,0 +1,27 @@
+package apiary
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// CacheTest returns the time the application started and the time that the
+// handler was last run. So if the result is cached, then one would expect that
+// the time the handler was last run would remain the same.
+func (s *Server) CacheTest() http.HandlerFunc {
+	startup := time.Now() // This will be captured by the closure at application startup time
+	return func(w http.ResponseWriter, r *http.Request) {
+		out := struct {
+			Startup time.Time `json:"startup"`
+			Handler time.Time `json:"handler"`
+		}{
+			Startup: startup,
+			Handler: time.Now(), // This will be the time the handler was run
+		}
+		response, _ := json.Marshal(out)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, string(response))
+	}
+}

--- a/cmd/apiary/cache_test.go
+++ b/cmd/apiary/cache_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+var response *httptest.ResponseRecorder
+
+func benchmarkEndpoint(path string, cache bool) {
+	// Add nocache to the URL
+	base, err := url.Parse(path)
+	if err != nil {
+		return
+	}
+	if !cache {
+		params := url.Values{}
+		params.Add("nocache", "")
+		base.RawQuery = params.Encode()
+	}
+	path = base.String()
+
+	// Run the request
+	req, _ := http.NewRequest("GET", path, nil)
+	response = executeRequest(req)
+}
+
+func BenchmarkCachedCounties(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		benchmarkEndpoint("/ahcb/counties/1874-05-08/", true)
+	}
+}
+
+func BenchmarkNotCachedCounties(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		benchmarkEndpoint("/ahcb/counties/1874-05-08/", false)
+	}
+}
+
+func BenchmarkCachedNorthAmerica(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		benchmarkEndpoint("/ne/northamerica/", true)
+	}
+}
+
+func BenchmarkNotCachedNorthAmerica(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		benchmarkEndpoint("/ne/northamerica/", false)
+	}
+}
+
+func BenchmarkCachedVerseTrend(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		benchmarkEndpoint("/apb/verse-trend?ref=Luke+18:16&corpus=chronam", true)
+	}
+}
+
+func BenchmarkNotCachedVerseTrend(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		benchmarkEndpoint("/apb/verse-trend?ref=Luke+18:16&corpus=chronam", false)
+	}
+}

--- a/endpoints.go
+++ b/endpoints.go
@@ -166,6 +166,12 @@ func (s *Server) EndpointsHandler() http.HandlerFunc {
 					{baseurl + "/relcensus/city-membership?year=1926",
 						"Membership data aggregated for all denominations in each city"},
 				}},
+			{"Cache test",
+				baseurl + "/cache",
+				[]ExampleURL{
+					{baseurl + "/cache", "Cached response"},
+					{baseurl + "/cache?nocache", "Uncached response"},
+				},
 		}
 
 		response, _ := json.MarshalIndent(endpoints, "", "  ")

--- a/endpoints.go
+++ b/endpoints.go
@@ -181,5 +181,3 @@ func (s *Server) EndpointsHandler() http.HandlerFunc {
 		fmt.Fprint(w, resp)
 	}
 }
-
-// []ExampleURL{{baseurl + "/ahcb/counties/1844-05-08/", "County on a specific date"}},

--- a/endpoints.go
+++ b/endpoints.go
@@ -172,6 +172,7 @@ func (s *Server) EndpointsHandler() http.HandlerFunc {
 					{baseurl + "/cache", "Cached response"},
 					{baseurl + "/cache?nocache", "Uncached response"},
 				},
+			},
 		}
 
 		response, _ := json.MarshalIndent(endpoints, "", "  ")

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/jackc/pgx/v4 v4.17.2
 	github.com/orlangure/gnomock v0.21.1
 	github.com/stretchr/testify v1.8.0
+	github.com/victorspringer/http-cache v0.0.0-20221006212759-e323d9f0f0c4
 )
 
 require (
@@ -38,7 +39,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
-	github.com/victorspringer/http-cache v0.0.0-20221006212759-e323d9f0f0c4 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.23.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
+	github.com/victorspringer/http-cache v0.0.0-20221006212759-e323d9f0f0c4 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -154,6 +154,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/victorspringer/http-cache v0.0.0-20221006212759-e323d9f0f0c4 h1:ihAF03tcseS9hMt7oOIzzE72RCci/z7A2DkJYl59zHE=
+github.com/victorspringer/http-cache v0.0.0-20221006212759-e323d9f0f0c4/go.mod h1:V7CEaXWuLs0tH3DNWqJO+GVr8YgiAwRgBh76T4LNSPU=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=

--- a/go.sum
+++ b/go.sum
@@ -237,7 +237,6 @@ golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
 golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=

--- a/middleware.go
+++ b/middleware.go
@@ -14,7 +14,8 @@ func (s *Server) Middleware() {
 	}
 	s.Router.Use(corsMiddleware)
 	s.Router.Use(clientCacheMiddleware)
-	s.Router.Use(handlers.CompressHandler)   // gzip requests
+	s.Router.Use(handlers.CompressHandler) // gzip requests
+	s.Router.Use(s.Cache.Middleware)
 	s.Router.Use(handlers.RecoveryHandler()) // Recover from runtime panics
 }
 

--- a/routes.go
+++ b/routes.go
@@ -35,6 +35,7 @@ func (s *Server) Routes() {
 	s.Router.HandleFunc("/relcensus/denomination-families", s.RelCensusDenominationFamiliesHandler()).Methods("GET", "HEAD")
 	s.Router.HandleFunc("/relcensus/denominations", s.RelCensusDenominationsHandler()).Methods("GET", "HEAD")
 	s.Router.HandleFunc("/relcensus/city-membership", s.RelCensusCityMembershipHandler()).Methods("GET", "HEAD")
+	s.Router.HandleFunc("/cache", s.CacheTest()).Methods("GET", "HEAD")
 	s.Router.HandleFunc("/", s.EndpointsHandler()).Methods("GET", "HEAD")
 
 	// Make sure to log 404 errors


### PR DESCRIPTION
@hepplerj @qtrinh2 

The data API's performance is acceptable. However, that is in part because it isn't under high load, and in part because we do some crude caching of expensive queries. For example, the [North America endpoint](https://github.com/chnm/apiary/blob/main/ne-northamerica.go) loads the data in a closure when the endpoint handler is created at startup. So the data is essentially saved in memory, and the handler will never go back to the database for new data until the application is restarted. This of course does not work if the endpoint actually needs some kind of parameter to know what to query, e.g., a date. We also set a pretty long-lived client-side cache, telling browsers not to ask for any endpoint [for one week](https://github.com/chnm/apiary/blob/main/middleware.go#L37).

Probably the biggest gain we could get in performance is to cache responses from the database. Even if the queries are small (and some are definitely not) the majority of the time is spent going out to the database. And there is a lot of reason to think that many of our queries are the same. E.g., a RelEc map will load the same data; APB will always query the featured verses.

We can probably cache in-memory, because we do not run multiple instances of the API, and because Baird has a lot of memory and isn't doing much else.

The simplest way to do this is to add middleware that caches the responses. That's what this draft pull request does. See the diff for details.

This passes all the tests. I've also added a test endpoint `/cache` which will show you the startup time and the time the handler was last called. The startup time will never change until application restart. The handler time will remain the same if the response is cached, until the TTL expires (currently an hour) or the memory limit for the cache is exceeded (unlikely in manual testing). You can also visit `/cache?nocache` to get an uncached version. That query parameter will work on any of the endpoints as well.

If we are going to do this, we will want to make sure we have set the right cache invalidation algorithm, the right TTL, and adjusted the client cache header accordingly. We will also want to test it before the release of APB on December 13, which is my motivation for adding this now. We will also want to check whether our crude, "closure caching" should be changed for any of the existing endpoints.

What are your thoughts?