### PR TITLE
moving popplaces_1926 table from public to relcensus schema

### DIFF
--- a/populated-places.go
+++ b/populated-places.go
@@ -45,7 +45,7 @@ func (s *Server) CountiesInState() http.HandlerFunc {
 
 	query := `
 		SELECT DISTINCT county_ahcb, county
-		FROM popplaces_1926
+		FROM relcensus.popplaces_1926
 		WHERE state = $1
 		ORDER BY county;
 		`
@@ -88,7 +88,7 @@ func (s *Server) PlacesInCounty() http.HandlerFunc {
 
 	query := `
 		SELECT place_id, place, map_name
-		FROM popplaces_1926
+		FROM relcensus.popplaces_1926
 		WHERE county_ahcb = $1
 		ORDER BY place;
 		`
@@ -131,7 +131,7 @@ func (s *Server) Place() http.HandlerFunc {
 
 	query := `
 		SELECT place_id, place, map_name, county, county_ahcb, state
-		FROM popplaces_1926
+		FROM relcensus.popplaces_1926
 		WHERE place_id = $1
 		`
 

--- a/relecensus-cities.go
+++ b/relecensus-cities.go
@@ -38,7 +38,7 @@ func (s *Server) RelCensusCityMembershipHandler() http.HandlerFunc {
 		ST_X(c.geometry) AS lon, ST_Y(c.geometry) AS lat
 		FROM relcensus.membership_city m
 		LEFT JOIN relcensus.cities_25K c ON m.city = c.city AND m.state = c.state
-		LEFT JOIN popplaces_1926 p ON c.place_id = p.place_id
+		LEFT JOIN relcensus.popplaces_1926 p ON c.place_id = p.place_id
 		WHERE year = $1 AND denomination = $2
 		ORDER BY state, city;
 	`
@@ -68,7 +68,7 @@ func (s *Server) RelCensusCityMembershipHandler() http.HandlerFunc {
 	GROUP BY m.year, d.family_relec, m.city, m.state
 	) d
 	LEFT JOIN relcensus.cities_25k c ON d.city = c.city AND d.state = c.state
-	LEFT JOIN popplaces_1926 p ON c.place_id = p.place_id
+	LEFT JOIN relcensus.popplaces_1926 p ON c.place_id = p.place_id
 	ORDER BY c.state, c.city;
 	`
 
@@ -95,7 +95,7 @@ func (s *Server) RelCensusCityMembershipHandler() http.HandlerFunc {
 	GROUP BY m.year, m.city, m.state
 	) d
 	LEFT JOIN relcensus.cities_25k c ON d.city = c.city AND d.state = c.state
-	LEFT JOIN popplaces_1926 p ON c.place_id = p.place_id
+	LEFT JOIN relcensus.popplaces_1926 p ON c.place_id = p.place_id
 	ORDER BY c.state, c.city;
 	`
 


### PR DESCRIPTION
I'll be moving the `popplaces_1926` table from the `public` schema to the `relcensus` schema.

Prepended references to `popplaces_1926` with `relcensus` schema.

I'll test a REST API endpoint that sources from this table when I deploy `apiary` to `dev.apiary.rrchnm.org`.


Will not deploy to production until I coordinate the changes to the database with the deployment of `apiary.`