### PR TITLE
Merge feature/cicd into main

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -7,7 +7,7 @@ on:
       - "feature/cicd"
     paths:
       - "**"
-      #- '!.github/**'
+      - '!.github/**'
 
 jobs:
   build-publish:
@@ -21,7 +21,7 @@ jobs:
       context-root: "."
 
       website-devl-fqdn: "dev.apiary.rrchnm.org"
-      website-prod-fqdn: "dev.apiary.rrchnm.org"
+      website-prod-fqdn: "data.chnm.org"
   
   deploy:
     uses: chnm/.github/.github/workflows/docker--deploy.yml@main
@@ -29,4 +29,4 @@ jobs:
     secrets: inherit
     with:
       website-devl-fqdn: "dev.apiary.rrchnm.org"
-      website-prod-fqdn: "dev.apiary.rrchnm.org"
+      website-prod-fqdn: "data.chnm.org"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,0 +1,23 @@
+name: "Build and Publish, Deploy Docker Image"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "feature/cicd"
+    paths:
+      - "**"
+
+jobs:
+  build-publish:
+    uses: chnm/.github/.github/workflows/django--build-publish.yml@main
+    secrets: inherit
+    with:
+
+      container-registry: "ghcr.io"
+      container-image-name: "apiary"
+      
+      django-context-root: "."
+
+      website-devl-fqdn: "dev.apiary.rrchnm.org"
+      website-prod-fqdn: "dev.apiary.rrchnm.org"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -7,18 +7,18 @@ on:
       - "feature/cicd"
     paths:
       - "**"
-      - '!.github/**'
+      #- '!.github/**'
 
 jobs:
   build-publish:
-    uses: chnm/.github/.github/workflows/django--build-publish.yml@main
+    uses: chnm/.github/.github/workflows/docker--build-publish.yml@main
     secrets: inherit
     with:
 
       container-registry: "ghcr.io"
       container-image-name: "apiary"
       
-      django-context-root: "."
+      context-root: "."
 
       website-devl-fqdn: "dev.apiary.rrchnm.org"
       website-prod-fqdn: "dev.apiary.rrchnm.org"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -7,6 +7,7 @@ on:
       - "feature/cicd"
     paths:
       - "**"
+      - '!.github/**'
 
 jobs:
   build-publish:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -22,3 +22,11 @@ jobs:
 
       website-devl-fqdn: "dev.apiary.rrchnm.org"
       website-prod-fqdn: "dev.apiary.rrchnm.org"
+  
+  deploy:
+    uses: chnm/.github/.github/workflows/docker--deploy.yml@main
+    needs: [build-publish]
+    secrets: inherit
+    with:
+      website-devl-fqdn: "dev.apiary.rrchnm.org"
+      website-prod-fqdn: "dev.apiary.rrchnm.org"


### PR DESCRIPTION
added cicd.yml workflow to auto build, publish, and deploy `apiary` on commit.
non-`main` commits should trigger workflow to deploy to dev.apiary.rrchnm.org.
`main` commits should trigger workflow to deploy to data.chnm.org.