### PR TITLE
feat: New endpoint for `relecensus` to return all location data

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -300,6 +300,11 @@ func (s *Server) EndpointsHandler() http.HandlerFunc {
 				nil,
 			},
 			{
+				"Religious Bodies List of all Cities",
+				baseurl + "/relcensus/cities/",
+				nil,
+			},
+			{
 				"Religious Bodies Census membership data for a denomination in a city in a year",
 				baseurl + "/relcensus/city-membership?year=1926&denomination=Protestant+Episcopal+Church",
 				[]ExampleURL{
@@ -333,3 +338,4 @@ func (s *Server) EndpointsHandler() http.HandlerFunc {
 		fmt.Fprint(w, resp)
 	}
 }
+

--- a/routes.go
+++ b/routes.go
@@ -38,6 +38,7 @@ func (s *Server) Routes() {
 	s.Router.HandleFunc("/relcensus/denomination-families", s.RelCensusDenominationFamiliesHandler()).Methods("GET", "HEAD")
 	s.Router.HandleFunc("/relcensus/denominations", s.RelCensusDenominationsHandler()).Methods("GET", "HEAD")
 	s.Router.HandleFunc("/relcensus/city-membership", s.RelCensusCityMembershipHandler()).Methods("GET", "HEAD")
+	s.Router.HandleFunc("/relcensus/cities", s.RelCensusLocationsHandler()).Methods("GET", "HEAD")
 	s.Router.HandleFunc("/cache", s.CacheTest()).Methods("GET", "HEAD")
 	s.Router.HandleFunc("/", s.EndpointsHandler()).Methods("GET", "HEAD")
 


### PR DESCRIPTION
The following commit adds a new endpoint to `relecensus` for returning all location data under a single endpoint. We primarily use this to sync location data between Apiary and the Django application.