### PR TITLE
refactor: Align results with data changes in the db

### DIFF
--- a/bom-shapefiles.go
+++ b/bom-shapefiles.go
@@ -128,8 +128,8 @@ func (s *Server) BillsShapefilesHandler() http.HandlerFunc {
             parishes_shp.start_yr,
             parishes_shp.sp_total,
             parishes_shp.sp_per,
-            COALESCE(SUM(CASE WHEN fb.count_type = 'Buried' THEN fb.count ELSE 0 END), 0) as total_buried,
-            COALESCE(SUM(CASE WHEN fb.count_type = 'Plague' THEN fb.count ELSE 0 END), 0) as total_plague,
+            COALESCE(SUM(CASE WHEN fb.count_type = 'buried' THEN fb.count ELSE 0 END), 0) as total_buried,
+            COALESCE(SUM(CASE WHEN fb.count_type = 'plague' THEN fb.count ELSE 0 END), 0) as total_plague,
             COUNT(fb.parish_id) as bill_count,
             parishes_shp.geom_01
         FROM 

--- a/endpoints.go
+++ b/endpoints.go
@@ -190,7 +190,7 @@ func (s *Server) EndpointsHandler() http.HandlerFunc {
 					},
 					{
 						baseurl + "/bom/bills?start-year=1636&end-year=1754&count-type=buried&limit=50&offset=0",
-						"Bills data for a specific count type (Buried or Plague). Specific parishes can be provided.",
+						"Bills data for a specific count type (buried or plague). Specific parishes can be provided.",
 					},
 					{
 						baseurl + "/bom/bills?start-year=1636&end-year=1754&bill-type=weekly&count-type=buried&limit=50&offset=0",


### PR DESCRIPTION
This pull request standardizes the usage of `count_type` values in SQL queries and endpoint documentation, ensuring they are always lowercase (`'buried'` and `'plague'`). It also improves query accuracy and consistency by making parish name comparisons case-insensitive and filtering out results with zero relevant counts.

**Query and Data Consistency Improvements:**

* Updated all SQL queries to use lowercase `'buried'` and `'plague'` for `count_type`, ensuring consistent data retrieval and preventing mismatches due to case sensitivity. [[1]](diffhunk://#diff-bd798bafec6c88ce39b59a8f0a4681a89362a885018cee52d1526eb3e561fe6eL663-R675) [[2]](diffhunk://#diff-d1ac581c865615287824df785d73434fbe748829c7ce1074c50ed2450cadcab1L131-R132)
* Made parish name filtering case-insensitive by applying `LOWER()` to both the column and parameter in the `buildParishYearlyStatsQuery` function.
* Added a `HAVING` clause to exclude records where the sum of `'buried'` and `'plague'` counts is zero, resulting in more relevant query results.

**Documentation Update:**

* Updated the endpoint description in `EndpointsHandler` to refer to `count_type` values as lowercase (`'buried'` or `'plague'`) for clarity and consistency with the code.