### PR TITLE
refactor: Include bill-type parameter for causes, include start/end week

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -196,6 +196,14 @@ func (s *Server) EndpointsHandler() http.HandlerFunc {
 						baseurl + "/bom/bills?start-year=1636&end-year=1754&bill-type=weekly&count-type=buried&limit=50&offset=0",
 						"Bill type (weekly or general) and count type (buried or plague) can be specific. Specific parishes can be provided.",
 					},
+					{
+						baseurl + "/bom/bills?start-year=1665&end-year=1665&start-week=10&end-week=15&limit=50&offset=0",
+						"Filter bills by week number range (1-53). Useful for seasonal analysis or specific time periods within a year.",
+					},
+					{
+						baseurl + "/bom/bills?start-year=1665&end-year=1665&start-week=50&bill-type=weekly&count-type=plague&limit=50&offset=0",
+						"Combine week number filtering with other parameters. Example shows plague deaths from week 50 onwards in 1665.",
+					},
 				},
 			},
 			{
@@ -204,15 +212,15 @@ func (s *Server) EndpointsHandler() http.HandlerFunc {
 				[]ExampleURL{
 					{
 						baseurl + "/bom/causes",
-						"Return all causes of death",
+						"Return all causes of death with bill_type indicating 'weekly' or 'general' bills",
 					},
 					{
 						baseurl + "/bom/causes?start-year=1648&end-year=1754",
-						"Causes of death for a specific year range",
+						"Causes of death for a specific year range with bill_type parameter",
 					},
 					{
-						baseurl + "/bom/causes?start-year=1648&end-year=1754&id=aged,drowned",
-						"Causes of death for a specific year range and cause IDs",
+						baseurl + "/bom/causes?start-year=1648&end-year=1754&bill-type=general&id=aged,drowned",
+						"Causes of death for a specific year range and cause IDs with bill_type parameter",
 					},
 				},
 			},


### PR DESCRIPTION
This pull request adds new filtering capabilities and improves API flexibility for the Bills of Mortality endpoints. The main changes include support for week-based filtering in the bills API, the addition of a `bill_type` filter in the causes of death API, and updates to the API documentation and response structures to reflect these enhancements.

**Bills API Enhancements:**

* Added `start-week` and `end-week` parameters to `APIParameters` and updated the query builder to filter results by week number, allowing clients to request data for specific week ranges. [[1]](diffhunk://#diff-bd798bafec6c88ce39b59a8f0a4681a89362a885018cee52d1526eb3e561fe6eR47-R48) [[2]](diffhunk://#diff-bd798bafec6c88ce39b59a8f0a4681a89362a885018cee52d1526eb3e561fe6eR227-R250) [[3]](diffhunk://#diff-bd798bafec6c88ce39b59a8f0a4681a89362a885018cee52d1526eb3e561fe6eR398-R405)
* Updated the API documentation and example URLs to demonstrate the new week-based filtering capabilities.

**Causes of Death API Enhancements:**

* Added support for filtering by `bill_type` (e.g., 'weekly' or 'general') in the causes of death endpoint, including validation, query parameter handling, and SQL query updates. [[1]](diffhunk://#diff-233fa5ddfbcd242f5757b37ebb5a8f4717f622641b36f6ca589b709e66df7840R26-L27) [[2]](diffhunk://#diff-233fa5ddfbcd242f5757b37ebb5a8f4717f622641b36f6ca589b709e66df7840R54) [[3]](diffhunk://#diff-233fa5ddfbcd242f5757b37ebb5a8f4717f622641b36f6ca589b709e66df7840R107-L110) [[4]](diffhunk://#diff-233fa5ddfbcd242f5757b37ebb5a8f4717f622641b36f6ca589b709e66df7840R144-R153) [[5]](diffhunk://#diff-233fa5ddfbcd242f5757b37ebb5a8f4717f622641b36f6ca589b709e66df7840R186-R198)
* Modified the response structure and row scanning logic to include the new `bill_type` field and removed the unused `descriptive_text` field. [[1]](diffhunk://#diff-233fa5ddfbcd242f5757b37ebb5a8f4717f622641b36f6ca589b709e66df7840R209-L185) [[2]](diffhunk://#diff-233fa5ddfbcd242f5757b37ebb5a8f4717f622641b36f6ca589b709e66df7840L200-R226)
* Updated the API documentation and example URLs to show how to use the new `bill_type` parameter.for general bills filtering