### PR TITLE
Add investigation type field

### DIFF
--- a/pinkertons.go
+++ b/pinkertons.go
@@ -27,6 +27,7 @@ type Activity struct {
 	InformationType NullString `json:"information_type"`
 	Edited          NullString `json:"edited"`
 	EditType        NullString `json:"edit_type"`
+	Investigation   NullString `json:"investigation"`
 	Locations       []Location `json:"locations,omitempty"`
 }
 
@@ -131,7 +132,7 @@ func (s *Server) ActivitiesHandler() http.HandlerFunc {
 		SELECT
 			a.id, a.source, a.operative, a.date, a.time, a.duration,
 			a.activity, a.mode, a.activity_notes, a.subject, a.information,
-			a.information_type, a.edited, a.edit_type
+			a.information_type, a.edited, a.edit_type, a.investigation
 		FROM detectives.activities a
 		WHERE 1=1
 		`
@@ -206,7 +207,7 @@ func (s *Server) ActivitiesHandler() http.HandlerFunc {
 				&row.ID, &row.Source, &row.Operative, &row.Date, &row.Time,
 				&row.Duration, &row.Activity, &row.Mode, &row.ActivityNotes,
 				&row.Subject, &row.Information, &row.InformationType,
-				&row.Edited, &row.EditType,
+				&row.Edited, &row.EditType, &row.Investigation,
 			)
 			if err != nil {
 				log.Println("Error scanning activity row:", err)
@@ -272,7 +273,7 @@ func (s *Server) ActivityByIDHandler() http.HandlerFunc {
 	SELECT
 		a.id, a.source, a.operative, a.date, a.time, a.duration,
 		a.activity, a.mode, a.activity_notes, a.subject, a.information,
-		a.information_type, a.edited, a.edit_type
+		a.information_type, a.edited, a.edit_type, a.investigation
 	FROM detectives.activities a
 	WHERE a.id = $1;
 	`
@@ -302,7 +303,7 @@ func (s *Server) ActivityByIDHandler() http.HandlerFunc {
 			&activity.ID, &activity.Source, &activity.Operative, &activity.Date,
 			&activity.Time, &activity.Duration, &activity.Activity, &activity.Mode,
 			&activity.ActivityNotes, &activity.Subject, &activity.Information,
-			&activity.InformationType, &activity.Edited, &activity.EditType,
+			&activity.InformationType, &activity.Edited, &activity.EditType, &activity.Investigation,
 		)
 		if err != nil {
 			log.Println("Error querying activity:", err)


### PR DESCRIPTION
This pull request adds support for the new `investigation` field to the `Activity` struct and ensures it is properly handled throughout the API. The changes update both the data model and the relevant SQL queries and scan logic to include this new field.

**Model update:**

* Added a new `Investigation` field of type `NullString` to the `Activity` struct to store investigation-related information.

**Database and API integration:**

* Updated the SQL SELECT statements in both the `ActivitiesHandler` and `ActivityByIDHandler` to include the `investigation` column when fetching activity records. [[1]](diffhunk://#diff-0f384524844450a391b8e7bb28d50d0025bd409a88e5afb2175bc8128e596fe4L134-R135) [[2]](diffhunk://#diff-0f384524844450a391b8e7bb28d50d0025bd409a88e5afb2175bc8128e596fe4L275-R276)
* Modified the `sql.Rows.Scan` and `db.QueryRow.Scan` calls to read the `investigation` value into the new struct field in both handlers. [[1]](diffhunk://#diff-0f384524844450a391b8e7bb28d50d0025bd409a88e5afb2175bc8128e596fe4L209-R210) [[2]](diffhunk://#diff-0f384524844450a391b8e7bb28d50d0025bd409a88e5afb2175bc8128e596fe4L305-R306)