### PR TITLE
Keep death cause query failures request-scoped

### DIFF
--- a/bom-causes.go
+++ b/bom-causes.go
@@ -204,10 +204,10 @@ func (s *Server) DeathCausesHandler() http.HandlerFunc {
 			params = append(params, billType)
 		}
 
-		rows, err = s.DB.Query(context.TODO(), query, params...)
+		rows, err = s.DB.Query(r.Context(), query, params...)
 		if err != nil {
+			log.Printf("error querying death causes: %v", err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-			log.Fatal("Error preparing statement", err)
 			return
 		}
 

--- a/bom-causes_test.go
+++ b/bom-causes_test.go
@@ -1,0 +1,40 @@
+package apiary
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestDeathCausesHandlerQueryErrorReturnsInternalServerError(t *testing.T) {
+	pool, err := pgxpool.New(
+		context.Background(),
+		"postgres://apiary:apiary@127.0.0.1:1/apiary",
+	)
+	if err != nil {
+		t.Fatalf("create database pool: %v", err)
+	}
+	pool.Close()
+
+	server := &Server{DB: pool}
+	request := httptest.NewRequest(
+		http.MethodGet,
+		"/bom/causes?start-year=1669&end-year=1754",
+		nil,
+	)
+	response := httptest.NewRecorder()
+
+	server.DeathCausesHandler().ServeHTTP(response, request)
+
+	if response.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusInternalServerError)
+	}
+
+	if body := strings.TrimSpace(response.Body.String()); body != http.StatusText(http.StatusInternalServerError) {
+		t.Fatalf("body = %q, want %q", body, http.StatusText(http.StatusInternalServerError))
+	}
+}


### PR DESCRIPTION
## Summary

Part of #100.

- replace the request-path `log.Fatal` in `DeathCausesHandler` with ordinary error logging
- return a generic HTTP 500 response without terminating the API process
- pass the incoming request context to the database query
- add a regression test that invokes the real handler with a closed pgx pool

## Root cause and impact

A database query error called `log.Fatal`, which writes the error and exits the process. A single failed `/bom/causes` request could therefore terminate the entire service.

The handler now keeps the failure within the request lifecycle, logs the internal database error server-side, and exposes only the standard `Internal Server Error` response to the client.

## Verification

- `go test -run TestDeathCausesHandlerQueryErrorReturnsInternalServerError -v .`
- `go test -race .`
- `go build ./...`
- `go vet ./...`
- `go test -v -run '^TestBomCauses$' ./cmd/apiary` against the live database
