### PR TITLE
Propagate request contexts through BOM queries

### DIFF
--- a/bom-bills.go
+++ b/bom-bills.go
@@ -1,7 +1,6 @@
 package apiary
 
 import (
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -128,7 +127,7 @@ func (s *Server) BillsHandler() http.HandlerFunc {
 		}
 
 		// Execute query with parameters
-		rows, err := s.DB.Query(context.TODO(), qb.Query, qb.Params...)
+		rows, err := s.DB.Query(r.Context(), qb.Query, qb.Params...)
 		if err != nil {
 			http.Error(w, "Database error", http.StatusInternalServerError)
 			log.Printf("Error executing query: %v", err)
@@ -644,16 +643,18 @@ func (s *Server) TotalBillsHandler() http.HandlerFunc {
 
 		switch {
 		case totalValues == "weekly":
-			rows, err = s.DB.Query(context.TODO(), queryWeekly)
+			rows, err = s.DB.Query(r.Context(), queryWeekly)
 		case totalValues == "general":
-			rows, err = s.DB.Query(context.TODO(), queryGeneral)
+			rows, err = s.DB.Query(r.Context(), queryGeneral)
 		case totalValues == "christenings":
-			rows, err = s.DB.Query(context.TODO(), queryChristenings)
+			rows, err = s.DB.Query(r.Context(), queryChristenings)
 		case totalValues == "causes":
-			rows, err = s.DB.Query(context.TODO(), queryCauses)
+			rows, err = s.DB.Query(r.Context(), queryCauses)
 		}
 		if err != nil {
 			log.Println(err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 		defer rows.Close()
 
@@ -788,10 +789,10 @@ func (s *Server) StatisticsHandler() http.HandlerFunc {
 		switch statType {
 		case "weekly":
 			query := buildWeeklyStatsQuery()
-			rows, err = s.DB.Query(context.TODO(), query)
+			rows, err = s.DB.Query(r.Context(), query)
 		case "yearly":
 			query := buildYearlyStatsQuery()
-			rows, err = s.DB.Query(context.TODO(), query)
+			rows, err = s.DB.Query(r.Context(), query)
 		case "parish-yearly":
 			qb, buildErr := buildParishYearlyStatsQuery(parishName)
 			if buildErr != nil {
@@ -799,7 +800,7 @@ func (s *Server) StatisticsHandler() http.HandlerFunc {
 				log.Printf("Error building parish-yearly query: %v", buildErr)
 				return
 			}
-			rows, err = s.DB.Query(context.TODO(), qb.Query, qb.Params...)
+			rows, err = s.DB.Query(r.Context(), qb.Query, qb.Params...)
 		default:
 			http.Error(w, "Invalid type parameter. Must be 'weekly', 'yearly', or 'parish-yearly'", http.StatusBadRequest)
 			return

--- a/bom-causes.go
+++ b/bom-causes.go
@@ -1,7 +1,6 @@
 package apiary
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -290,9 +289,9 @@ func (s *Server) ListCausesHandler() http.HandlerFunc {
 
 		// Execute query with or without bill type parameter
 		if billType != "" {
-			rows, err = s.DB.Query(context.TODO(), query, billType)
+			rows, err = s.DB.Query(r.Context(), query, billType)
 		} else {
-			rows, err = s.DB.Query(context.TODO(), query)
+			rows, err = s.DB.Query(r.Context(), query)
 		}
 
 		if err != nil {

--- a/bom-christenings.go
+++ b/bom-christenings.go
@@ -1,7 +1,6 @@
 package apiary
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -170,15 +169,17 @@ func (s *Server) ChristeningsHandler() http.HandlerFunc {
 
 		switch {
 		case location == "{}":
-			rows, err = s.DB.Query(context.TODO(), query, startYearInt, endYearInt, limitInt, offsetInt, billTypeParam)
+			rows, err = s.DB.Query(r.Context(), query, startYearInt, endYearInt, limitInt, offsetInt, billTypeParam)
 		case location != "{}":
-			rows, err = s.DB.Query(context.TODO(), queryLocation, startYearInt, endYearInt, location, limitInt, offsetInt, billTypeParam)
+			rows, err = s.DB.Query(r.Context(), queryLocation, startYearInt, endYearInt, location, limitInt, offsetInt, billTypeParam)
 		default:
-			rows, err = s.DB.Query(context.TODO(), query, startYearInt, endYearInt, limitInt, offsetInt, billTypeParam)
+			rows, err = s.DB.Query(r.Context(), query, startYearInt, endYearInt, limitInt, offsetInt, billTypeParam)
 		}
 
 		if err != nil {
 			log.Println(err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 		defer rows.Close()
 		for rows.Next() {
@@ -250,9 +251,9 @@ func (s *Server) ListChristeningsHandler() http.HandlerFunc {
 
 		// Execute query with or without bill type parameter
 		if billType != "" {
-			rows, err = s.DB.Query(context.TODO(), query, billType)
+			rows, err = s.DB.Query(r.Context(), query, billType)
 		} else {
-			rows, err = s.DB.Query(context.TODO(), query)
+			rows, err = s.DB.Query(r.Context(), query)
 		}
 
 		if err != nil {

--- a/bom-parishes.go
+++ b/bom-parishes.go
@@ -74,9 +74,11 @@ func (s *Server) ParishesHandler() http.HandlerFunc {
 		results := make([]Parish, 0)
 		var row Parish
 
-		rows, err := s.DB.Query(context.TODO(), query)
+		rows, err := s.DB.Query(r.Context(), query)
 		if err != nil {
 			log.Println(err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 		defer rows.Close()
 		for rows.Next() {
@@ -90,6 +92,7 @@ func (s *Server) ParishesHandler() http.HandlerFunc {
 		if err != nil {
 			log.Println(err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 
 		response, _ := json.Marshal(results)

--- a/bom-shapefiles.go
+++ b/bom-shapefiles.go
@@ -84,9 +84,9 @@ func (s *Server) ParishShpHandler() http.HandlerFunc {
 		var err error
 
 		if len(params) == 0 {
-			err = s.DB.QueryRow(context.Background(), query).Scan(&result)
+			err = s.DB.QueryRow(r.Context(), query).Scan(&result)
 		} else {
-			err = s.DB.QueryRow(context.Background(), query, params...).Scan(&result)
+			err = s.DB.QueryRow(r.Context(), query, params...).Scan(&result)
 		}
 
 		if err != nil {

--- a/bom_context_test.go
+++ b/bom_context_test.go
@@ -1,0 +1,169 @@
+package apiary
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type bomRequestContextKey struct{}
+
+const bomRequestContextMarker = "bom-request-context"
+
+func TestBOMHandlersPropagateRequestCancellation(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		handler func(*Server) http.HandlerFunc
+	}{
+		{
+			name: "bills",
+			path: "/bom/bills?start-year=1669&end-year=1670&bill-type=weekly",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.BillsHandler()
+			},
+		},
+		{
+			name: "total bills",
+			path: "/bom/totalbills?type=weekly",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.TotalBillsHandler()
+			},
+		},
+		{
+			name: "statistics",
+			path: "/bom/statistics?type=yearly",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.StatisticsHandler()
+			},
+		},
+		{
+			name: "death causes",
+			path: "/bom/causes?start-year=1669&end-year=1670",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.DeathCausesHandler()
+			},
+		},
+		{
+			name: "list causes",
+			path: "/bom/list-deaths",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.ListCausesHandler()
+			},
+		},
+		{
+			name: "christenings",
+			path: "/bom/christenings?start-year=1669&end-year=1670",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.ChristeningsHandler()
+			},
+		},
+		{
+			name: "list christenings",
+			path: "/bom/list-christenings",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.ListChristeningsHandler()
+			},
+		},
+		{
+			name: "parishes",
+			path: "/bom/parishes",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.ParishesHandler()
+			},
+		},
+		{
+			name: "parish geometries",
+			path: "/bom/geometries",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.ParishShpHandler()
+			},
+		},
+		{
+			name: "bill geometries",
+			path: "/bom/shapefiles?start-year=1669&end-year=1670&bill-type=weekly&count-type=plague",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.BillsShapefilesHandler()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			observedContext := make(chan context.Context, 1)
+			config, err := pgxpool.ParseConfig(
+				"postgres://apiary:apiary@127.0.0.1:1/apiary",
+			)
+			if err != nil {
+				t.Fatalf("parse database config: %v", err)
+			}
+			config.BeforeConnect = func(ctx context.Context, _ *pgx.ConnConfig) error {
+				observedContext <- ctx
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(2 * time.Second):
+					return errors.New("database context was not canceled")
+				}
+			}
+
+			pool, err := pgxpool.NewWithConfig(context.Background(), config)
+			if err != nil {
+				t.Fatalf("create database pool: %v", err)
+			}
+			t.Cleanup(pool.Close)
+
+			requestContext := context.WithValue(
+				context.Background(),
+				bomRequestContextKey{},
+				bomRequestContextMarker,
+			)
+			requestContext, cancel := context.WithCancel(requestContext)
+			t.Cleanup(cancel)
+
+			request := httptest.NewRequest(http.MethodGet, tt.path, nil).
+				WithContext(requestContext)
+			response := httptest.NewRecorder()
+			handlerDone := make(chan any, 1)
+
+			go func() {
+				var panicValue any
+				defer func() {
+					panicValue = recover()
+					handlerDone <- panicValue
+				}()
+				tt.handler(&Server{DB: pool}).ServeHTTP(response, request)
+			}()
+
+			select {
+			case databaseContext := <-observedContext:
+				if marker := databaseContext.Value(bomRequestContextKey{}); marker != bomRequestContextMarker {
+					t.Errorf("database context marker = %v, want %q", marker, bomRequestContextMarker)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("handler did not start a database query")
+			}
+
+			cancel()
+
+			select {
+			case panicValue := <-handlerDone:
+				if panicValue != nil {
+					t.Fatalf("handler panicked after cancellation: %v", panicValue)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("handler did not stop after request cancellation")
+			}
+
+			if response.Code != http.StatusInternalServerError {
+				t.Fatalf("status = %d, want %d", response.Code, http.StatusInternalServerError)
+			}
+		})
+	}
+}

--- a/cmd/apiary/bom_test.go
+++ b/cmd/apiary/bom_test.go
@@ -61,6 +61,34 @@ func TestBomBills(t *testing.T) {
 	}
 }
 
+func TestBomTotalBills(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/bom/totalbills?type=weekly", nil)
+	response := executeRequest(req)
+	checkResponseCode(t, http.StatusOK, response.Code)
+
+	var data []apiary.TotalBills
+	if err := json.Unmarshal(response.Body.Bytes(), &data); err != nil {
+		t.Fatal(err)
+	}
+	if len(data) == 0 {
+		t.Fatal("expected total bill data")
+	}
+}
+
+func TestBomStatistics(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/bom/statistics?type=yearly", nil)
+	response := executeRequest(req)
+	checkResponseCode(t, http.StatusOK, response.Code)
+
+	var data []apiary.YearlySummary
+	if err := json.Unmarshal(response.Body.Bytes(), &data); err != nil {
+		t.Fatal(err)
+	}
+	if len(data) == 0 {
+		t.Fatal("expected yearly statistics")
+	}
+}
+
 func TestBomChristenings(t *testing.T) {
 	// Check that we get the right response
 	req, _ := http.NewRequest("GET", "/bom/christenings?start-year=1669&end-year=1754", nil)


### PR DESCRIPTION
## Summary

Part of #100.

- pass `r.Context()` to all 18 database calls across the BOM handler family
- cover all ten affected handlers with a table-driven cancellation regression test
- return a generic HTTP 500 instead of continuing with nil rows when total-bills, christenings, or parish queries fail
- add live success-path integration coverage for `/bom/totalbills` and `/bom/statistics`

## Impact

Client disconnects, request cancellation, and server shutdown can now cancel in-flight BOM database work instead of leaving queries attached to background contexts.

The cancellation test passes a request marker through pgx, cancels each request, and verifies that every handler exits promptly without panicking.

## Verification

- `go mod tidy -diff`
- `go test -run TestBOMHandlersPropagateRequestCancellation -v .`
- `go test -race .`
- `go build ./...`
- `go vet ./...`
- live-database tests for bills, causes, christenings, parishes, cause/christening lists, total bills, yearly statistics, and bounded shapefile filters

## Follow-up observation

The existing unbounded `TestBomCauses` success-path test passed but took approximately 121 seconds. Query performance and bounded defaults remain follow-up work under #100.
