### PR TITLE
Propagate request contexts through APB queries

### DIFF
--- a/apb-bible-similarity.go
+++ b/apb-bible-similarity.go
@@ -1,7 +1,6 @@
 package apiary
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -48,9 +47,11 @@ func (s *Server) APBBibleSimilarityHandler() http.HandlerFunc {
 		var edge BibleSimilarityEdge
 		var result []BibleSimilarityEdge
 
-		rows, err := s.DB.Query(context.TODO(), query)
+		rows, err := s.DB.Query(r.Context(), query)
 		if err != nil {
 			log.Println(err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 		defer rows.Close()
 

--- a/apb-bible-trend.go
+++ b/apb-bible-trend.go
@@ -1,7 +1,6 @@
 package apiary
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -41,9 +40,11 @@ func (s *Server) APBBibleTrendHandler() http.HandlerFunc {
 		results := make([]VerseTrend, 0, 87) // Preallocate slice capacity
 		var row VerseTrend
 
-		rows, err := s.DB.Query(context.TODO(), query, corpus, minYear, maxYear)
+		rows, err := s.DB.Query(r.Context(), query, corpus, minYear, maxYear)
 		if err != nil {
 			log.Println(err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 		defer rows.Close()
 		for rows.Next() {

--- a/apb-bible.go
+++ b/apb-bible.go
@@ -1,7 +1,6 @@
 package apiary
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -30,9 +29,11 @@ func (s *Server) APBBibleBooksHandler() http.HandlerFunc {
 		var result []BibleBook
 		var book BibleBook
 
-		rows, err := s.DB.Query(context.TODO(), query)
+		rows, err := s.DB.Query(r.Context(), query)
 		if err != nil {
 			log.Println(err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 		defer rows.Close()
 

--- a/apb-index.go
+++ b/apb-index.go
@@ -1,7 +1,6 @@
 package apiary
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -46,9 +45,11 @@ func (s *Server) APBIndexFeaturedHandler() http.HandlerFunc {
 		var results []APBIndexItem
 		var row APBIndexItem
 
-		rows, err := s.DB.Query(context.TODO(), query)
+		rows, err := s.DB.Query(r.Context(), query)
 		if err != nil {
 			log.Println(err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 		defer rows.Close()
 		for rows.Next() {
@@ -87,9 +88,11 @@ func (s *Server) APBIndexBiblicalOrderHandler() http.HandlerFunc {
 		var results []APBIndexItem
 		var row APBIndexItem
 
-		rows, err := s.DB.Query(context.TODO(), query)
+		rows, err := s.DB.Query(r.Context(), query)
 		if err != nil {
 			log.Println(err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 		defer rows.Close()
 		for rows.Next() {
@@ -128,9 +131,11 @@ func (s *Server) APBIndexTopHandler() http.HandlerFunc {
 		var results []APBIndexItem
 		var row APBIndexItem
 
-		rows, err := s.DB.Query(context.TODO(), query)
+		rows, err := s.DB.Query(r.Context(), query)
 		if err != nil {
 			log.Println(err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 		defer rows.Close()
 		for rows.Next() {
@@ -170,9 +175,11 @@ func (s *Server) APBIndexChronologicalHandler() http.HandlerFunc {
 		var results []APBIndexItemWithYear
 		var row APBIndexItemWithYear
 
-		rows, err := s.DB.Query(context.TODO(), query)
+		rows, err := s.DB.Query(r.Context(), query)
 		if err != nil {
 			log.Println(err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 		defer rows.Close()
 		for rows.Next() {
@@ -211,9 +218,11 @@ func (s *Server) APBIndexAllHandler() http.HandlerFunc {
 		var results []APBIndexItemText
 		var row APBIndexItemText
 
-		rows, err := s.DB.Query(context.TODO(), query)
+		rows, err := s.DB.Query(r.Context(), query)
 		if err != nil {
 			log.Println(err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 		defer rows.Close()
 		for rows.Next() {

--- a/apb-verse-quotations.go
+++ b/apb-verse-quotations.go
@@ -1,7 +1,6 @@
 package apiary
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -39,9 +38,11 @@ func (s *Server) APBVerseQuotationsHandler() http.HandlerFunc {
 		results := make([]VerseQuotation, 0)
 		var row VerseQuotation
 
-		rows, err := s.DB.Query(context.TODO(), query, refs[0])
+		rows, err := s.DB.Query(r.Context(), query, refs[0])
 		if err != nil {
 			log.Println(err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 		defer rows.Close()
 		for rows.Next() {

--- a/apb-verse-trend.go
+++ b/apb-verse-trend.go
@@ -1,7 +1,6 @@
 package apiary
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -85,9 +84,11 @@ func (s *Server) APBVerseTrendHandler() http.HandlerFunc {
 		results := make([]VerseTrend, 0, 175) // Preallocate slice capacity
 		var row VerseTrend
 
-		rows, err := s.DB.Query(context.TODO(), query, corpus, ref, minYear, maxYear)
+		rows, err := s.DB.Query(r.Context(), query, corpus, ref, minYear, maxYear)
 		if err != nil {
 			log.Println(err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 		defer rows.Close()
 		for rows.Next() {

--- a/apb-verse.go
+++ b/apb-verse.go
@@ -1,7 +1,6 @@
 package apiary
 
 import (
-	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -45,19 +44,23 @@ func (s *Server) APBVerseHandler() http.HandlerFunc {
 
 		var result Verse
 
-		err := s.DB.QueryRow(context.TODO(), verseQuery, refs[0]).Scan(&result.Reference, &result.Text)
+		err := s.DB.QueryRow(r.Context(), verseQuery, refs[0]).Scan(&result.Reference, &result.Text)
 		if err == sql.ErrNoRows {
 			w.WriteHeader(http.StatusNotFound)
 			w.Write([]byte("404 Not found."))
 			return
 		} else if err != nil {
 			log.Println(err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 
 		related := make([]string, 0)
-		rows, err := s.DB.Query(context.TODO(), relatedVerseQuery, refs[0])
+		rows, err := s.DB.Query(r.Context(), relatedVerseQuery, refs[0])
 		if err != nil {
 			log.Println(err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 		defer rows.Close()
 		var rel string

--- a/apb_context_test.go
+++ b/apb_context_test.go
@@ -1,0 +1,180 @@
+package apiary
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type apbRequestContextKey struct{}
+
+const apbRequestContextMarker = "apb-request-context"
+
+func TestAPBHandlersPropagateRequestCancellation(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		handler func(*Server) http.HandlerFunc
+	}{
+		{
+			name: "featured index",
+			path: "/apb/index/featured",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.APBIndexFeaturedHandler()
+			},
+		},
+		{
+			name: "biblical index",
+			path: "/apb/index/biblical",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.APBIndexBiblicalOrderHandler()
+			},
+		},
+		{
+			name: "top index",
+			path: "/apb/index/top",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.APBIndexTopHandler()
+			},
+		},
+		{
+			name: "chronological index",
+			path: "/apb/index/peaks",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.APBIndexChronologicalHandler()
+			},
+		},
+		{
+			name: "all index",
+			path: "/apb/index/all",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.APBIndexAllHandler()
+			},
+		},
+		{
+			name: "bible books",
+			path: "/apb/bible-books",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.APBBibleBooksHandler()
+			},
+		},
+		{
+			name: "bible similarity",
+			path: "/apb/bible-similarity",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.APBBibleSimilarityHandler()
+			},
+		},
+		{
+			name: "bible trend",
+			path: "/apb/bible-trend",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.APBBibleTrendHandler()
+			},
+		},
+		{
+			name: "verse",
+			path: "/apb/verse?ref=Genesis+1:1",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.APBVerseHandler()
+			},
+		},
+		{
+			name: "verse trend",
+			path: "/apb/verse-trend?ref=Genesis+1:1&corpus=chronam",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.APBVerseTrendHandler()
+			},
+		},
+		{
+			name: "verse quotations",
+			path: "/apb/verse-quotations?ref=Genesis+1:1",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.APBVerseQuotationsHandler()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			observedContext := make(chan context.Context, 1)
+			config, err := pgxpool.ParseConfig(
+				"postgres://apiary:apiary@127.0.0.1:1/apiary",
+			)
+			if err != nil {
+				t.Fatalf("parse database config: %v", err)
+			}
+			config.BeforeConnect = func(ctx context.Context, _ *pgx.ConnConfig) error {
+				observedContext <- ctx
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(2 * time.Second):
+					return errors.New("database context was not canceled")
+				}
+			}
+
+			pool, err := pgxpool.NewWithConfig(context.Background(), config)
+			if err != nil {
+				t.Fatalf("create database pool: %v", err)
+			}
+			t.Cleanup(pool.Close)
+
+			requestContext := context.WithValue(
+				context.Background(),
+				apbRequestContextKey{},
+				apbRequestContextMarker,
+			)
+			requestContext, cancel := context.WithCancel(requestContext)
+			t.Cleanup(cancel)
+
+			request := httptest.NewRequest(http.MethodGet, tt.path, nil).
+				WithContext(requestContext)
+			response := httptest.NewRecorder()
+			handlerDone := make(chan any, 1)
+
+			go func() {
+				var panicValue any
+				defer func() {
+					panicValue = recover()
+					handlerDone <- panicValue
+				}()
+				tt.handler(&Server{DB: pool}).ServeHTTP(response, request)
+			}()
+
+			select {
+			case databaseContext := <-observedContext:
+				if marker := databaseContext.Value(apbRequestContextKey{}); marker != apbRequestContextMarker {
+					t.Errorf("database context marker = %v, want %q", marker, apbRequestContextMarker)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("handler did not start a database query")
+			}
+
+			cancel()
+
+			select {
+			case panicValue := <-handlerDone:
+				if panicValue != nil {
+					t.Fatalf("handler panicked after cancellation: %v", panicValue)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("handler did not stop after request cancellation")
+			}
+
+			if response.Code != http.StatusInternalServerError {
+				t.Fatalf("status = %d, want %d", response.Code, http.StatusInternalServerError)
+			}
+			if body := strings.TrimSpace(response.Body.String()); body != http.StatusText(http.StatusInternalServerError) {
+				t.Fatalf("body = %q, want %q", body, http.StatusText(http.StatusInternalServerError))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- propagate each APB handler's HTTP request context through all 12 database calls
- return a generic 500 and stop when an APB query cannot be started, preventing cancellation errors from reaching a nil `rows`
- add table-driven regression coverage proving all 11 APB handlers pass request values and cancellation to pgx and exit without panicking

## Why

The APB handlers used `context.TODO()` for database work, so a query could continue after its client disconnected or its request was canceled. Query failures were also logged without returning, which allowed handlers to call `Close` on a nil row set.

Successful response bodies and route parameters are unchanged. This is the next request-lifecycle slice from #100.

## Validation

- `go mod tidy -diff`
- `go test -race . -count=1`
- `go test -race . -run 'TestAPBHandlersPropagateRequestCancellation' -count=1`
- `go test ./cmd/apiary -run 'Test(APB|BiblicalIndex|BibleAllIndex|BibleSimilarity|BibleBooks)' -count=1 -v`
- `go build ./...`
- `go vet ./...`
- `go run honnef.co/go/tools/cmd/staticcheck@v0.6.1 ./...`
- `go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...` — no vulnerabilities found
- all five GitHub Actions checks

## Consumer verification

The source for [America's Public Bible](https://github.com/lmullen/americas-public-bible) was checked against the API response fields. All 12 requests used by the project—including both verse-trend corpora—returned valid production JSON with the expected keys.

Live browser smoke tests at [America's Public Bible](https://americaspublicbible.supdigital.org/) also passed:

- the homepage rendered its featured verses and visualizations without browser warnings
- the most-quoted page rendered 100 verse sparklines
- the Luke 2:14 viewer rendered its trend chart and 7,269 quotation links
