### PR TITLE
Propagate request contexts through Pinkertons queries

### DIFF
--- a/cmd/apiary/pinkertons_test.go
+++ b/cmd/apiary/pinkertons_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestDetectivesActivities(t *testing.T) {
 	// Check that we get the right response
-	req, _ := http.NewRequest("GET", "/pinkertons/activities", nil)
+	req, _ := http.NewRequest("GET", "/pinkertons/activities?limit=10", nil)
 	response := executeRequest(req)
 	checkResponseCode(t, http.StatusOK, response.Code)
 
@@ -30,7 +30,7 @@ func TestDetectivesActivities(t *testing.T) {
 
 func TestDetectivesActivitiesWithLocations(t *testing.T) {
 	// Check that we get activities with locations included
-	req, _ := http.NewRequest("GET", "/pinkertons/activities?include_locations=true", nil)
+	req, _ := http.NewRequest("GET", "/pinkertons/activities?include_locations=true&limit=10", nil)
 	response := executeRequest(req)
 	checkResponseCode(t, http.StatusOK, response.Code)
 
@@ -95,7 +95,7 @@ func TestDetectivesActivitiesFilterByDateRange(t *testing.T) {
 
 func TestDetectivesActivityByID(t *testing.T) {
 	// First, get all activities to find a valid ID
-	req, _ := http.NewRequest("GET", "/pinkertons/activities", nil)
+	req, _ := http.NewRequest("GET", "/pinkertons/activities?limit=1", nil)
 	response := executeRequest(req)
 
 	if response.Code != http.StatusOK {

--- a/pinkertons.go
+++ b/pinkertons.go
@@ -3,12 +3,14 @@ package apiary
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
 	"strconv"
 
 	"github.com/gorilla/mux"
+	"github.com/jackc/pgx/v5"
 )
 
 // Activity represents a detective activity from the database
@@ -43,6 +45,48 @@ type Location struct {
 	Visits               NullInt64   `json:"visits"`
 	Latitude             NullFloat64 `json:"latitude"`
 	Longitude            NullFloat64 `json:"longitude"`
+}
+
+const activityLocationsQuery = `
+SELECT
+	l.id, l.locality, l.street_address, l.location_name,
+	l.location_type, l.specific_location_type, l.location_notes, l.visits, l.latitude, l.longitude
+FROM detectives.locations l
+INNER JOIN detectives.activity_locations al ON l.id = al.location_id
+WHERE al.activity_id = $1;
+`
+
+func (s *Server) activityLocations(ctx context.Context, activityID int) ([]Location, error) {
+	locations := make([]Location, 0)
+	rows, err := s.DB.Query(ctx, activityLocationsQuery, activityID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var location Location
+		if err := rows.Scan(
+			&location.ID,
+			&location.Locality,
+			&location.StreetAddress,
+			&location.LocationName,
+			&location.LocationType,
+			&location.SpecificLocationType,
+			&location.LocationNotes,
+			&location.Visits,
+			&location.Latitude,
+			&location.Longitude,
+		); err != nil {
+			return nil, err
+		}
+		locations = append(locations, location)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return locations, nil
 }
 
 // NullFloat64 handles nullable float64 values for JSON marshaling
@@ -193,7 +237,7 @@ func (s *Server) ActivitiesHandler() http.HandlerFunc {
 
 		results := make([]Activity, 0)
 
-		rows, err := s.DB.Query(context.TODO(), baseQuery, args...)
+		rows, err := s.DB.Query(r.Context(), baseQuery, args...)
 		if err != nil {
 			log.Println("Error querying activities:", err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -211,7 +255,8 @@ func (s *Server) ActivitiesHandler() http.HandlerFunc {
 			)
 			if err != nil {
 				log.Println("Error scanning activity row:", err)
-				continue
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				return
 			}
 			results = append(results, row)
 		}
@@ -222,37 +267,14 @@ func (s *Server) ActivitiesHandler() http.HandlerFunc {
 			return
 		}
 
-		// Fetch locations for each activity
-		locationsQuery := `
-		SELECT
-			l.id, l.locality, l.street_address, l.location_name,
-			l.location_type, l.specific_location_type, l.location_notes, l.visits, l.latitude, l.longitude
-		FROM detectives.locations l
-		INNER JOIN detectives.activity_locations al ON l.id = al.location_id
-		WHERE al.activity_id = $1;
-		`
-
 		for i := range results {
-			results[i].Locations = make([]Location, 0)
-			locRows, err := s.DB.Query(context.TODO(), locationsQuery, results[i].ID)
+			locations, err := s.activityLocations(r.Context(), results[i].ID)
 			if err != nil {
 				log.Println("Error querying locations for activity", results[i].ID, ":", err)
-				continue
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				return
 			}
-
-			for locRows.Next() {
-				var loc Location
-				err := locRows.Scan(
-					&loc.ID, &loc.Locality, &loc.StreetAddress, &loc.LocationName,
-					&loc.LocationType, &loc.SpecificLocationType, &loc.LocationNotes, &loc.Visits, &loc.Latitude, &loc.Longitude,
-				)
-				if err != nil {
-					log.Println("Error scanning location row:", err)
-					continue
-				}
-				results[i].Locations = append(results[i].Locations, loc)
-			}
-			locRows.Close()
+			results[i].Locations = locations
 		}
 
 		response, err := json.Marshal(results)
@@ -278,15 +300,6 @@ func (s *Server) ActivityByIDHandler() http.HandlerFunc {
 	WHERE a.id = $1;
 	`
 
-	locationsQuery := `
-	SELECT
-		l.id, l.locality, l.street_address, l.location_name,
-		l.location_type, l.specific_location_type, l.location_notes, l.visits, l.latitude, l.longitude
-	FROM detectives.locations l
-	INNER JOIN detectives.activity_locations al ON l.id = al.location_id
-	WHERE al.activity_id = $1;
-	`
-
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
 		idStr := vars["id"]
@@ -299,37 +312,28 @@ func (s *Server) ActivityByIDHandler() http.HandlerFunc {
 		var activity Activity
 
 		// Get activity
-		err = s.DB.QueryRow(context.TODO(), activityQuery, id).Scan(
+		err = s.DB.QueryRow(r.Context(), activityQuery, id).Scan(
 			&activity.ID, &activity.Source, &activity.Operative, &activity.Date,
 			&activity.Time, &activity.Duration, &activity.Activity, &activity.Mode,
 			&activity.ActivityNotes, &activity.Subject, &activity.Information,
 			&activity.InformationType, &activity.Edited, &activity.EditType, &activity.Investigation,
 		)
+		if errors.Is(err, pgx.ErrNoRows) {
+			http.Error(w, "Activity not found", http.StatusNotFound)
+			return
+		}
 		if err != nil {
 			log.Println("Error querying activity:", err)
-			http.Error(w, "Activity not found", http.StatusNotFound)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
 
 		// Get locations for this activity
-		activity.Locations = make([]Location, 0)
-		rows, err := s.DB.Query(context.TODO(), locationsQuery, id)
+		activity.Locations, err = s.activityLocations(r.Context(), id)
 		if err != nil {
 			log.Println("Error querying locations:", err)
-		} else {
-			defer rows.Close()
-			for rows.Next() {
-				var loc Location
-				err := rows.Scan(
-					&loc.ID, &loc.Locality, &loc.StreetAddress, &loc.LocationName,
-					&loc.LocationType, &loc.SpecificLocationType, &loc.LocationNotes, &loc.Visits, &loc.Latitude, &loc.Longitude,
-				)
-				if err != nil {
-					log.Println("Error scanning location row:", err)
-					continue
-				}
-				activity.Locations = append(activity.Locations, loc)
-			}
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 
 		response, err := json.Marshal(activity)
@@ -357,7 +361,7 @@ func (s *Server) LocationsHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		results := make([]Location, 0)
 
-		rows, err := s.DB.Query(context.TODO(), query)
+		rows, err := s.DB.Query(r.Context(), query)
 		if err != nil {
 			log.Println("Error querying locations:", err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -373,7 +377,8 @@ func (s *Server) LocationsHandler() http.HandlerFunc {
 			)
 			if err != nil {
 				log.Println("Error scanning location row:", err)
-				continue
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				return
 			}
 			results = append(results, row)
 		}
@@ -408,7 +413,7 @@ func (s *Server) OperativesHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		results := make([]string, 0)
 
-		rows, err := s.DB.Query(context.TODO(), query)
+		rows, err := s.DB.Query(r.Context(), query)
 		if err != nil {
 			log.Println("Error querying operatives:", err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -421,7 +426,8 @@ func (s *Server) OperativesHandler() http.HandlerFunc {
 			err := rows.Scan(&operative)
 			if err != nil {
 				log.Println("Error scanning operative:", err)
-				continue
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				return
 			}
 			results = append(results, operative)
 		}
@@ -456,7 +462,7 @@ func (s *Server) SubjectsHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		results := make([]string, 0)
 
-		rows, err := s.DB.Query(context.TODO(), query)
+		rows, err := s.DB.Query(r.Context(), query)
 		if err != nil {
 			log.Println("Error querying subjects:", err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -469,7 +475,8 @@ func (s *Server) SubjectsHandler() http.HandlerFunc {
 			err := rows.Scan(&subject)
 			if err != nil {
 				log.Println("Error scanning subject:", err)
-				continue
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				return
 			}
 			results = append(results, subject)
 		}

--- a/pinkertons_context_test.go
+++ b/pinkertons_context_test.go
@@ -1,0 +1,192 @@
+package apiary
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type pinkertonsRequestContextKey struct{}
+
+const pinkertonsRequestContextMarker = "pinkertons-request-context"
+
+func newPinkertonsCancellationPool(
+	t *testing.T,
+	observedContext chan<- context.Context,
+) *pgxpool.Pool {
+	t.Helper()
+
+	config, err := pgxpool.ParseConfig(
+		"postgres://apiary:apiary@127.0.0.1:1/apiary",
+	)
+	if err != nil {
+		t.Fatalf("parse database config: %v", err)
+	}
+	config.BeforeConnect = func(ctx context.Context, _ *pgx.ConnConfig) error {
+		observedContext <- ctx
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(2 * time.Second):
+			return errors.New("database context was not canceled")
+		}
+	}
+
+	pool, err := pgxpool.NewWithConfig(context.Background(), config)
+	if err != nil {
+		t.Fatalf("create database pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+func newPinkertonsRequest(t *testing.T, path string) (*http.Request, context.CancelFunc) {
+	t.Helper()
+
+	requestContext := context.WithValue(
+		context.Background(),
+		pinkertonsRequestContextKey{},
+		pinkertonsRequestContextMarker,
+	)
+	requestContext, cancel := context.WithCancel(requestContext)
+	request := httptest.NewRequest(http.MethodGet, path, nil).
+		WithContext(requestContext)
+	return request, cancel
+}
+
+func assertPinkertonsDatabaseContext(
+	t *testing.T,
+	observedContext <-chan context.Context,
+) {
+	t.Helper()
+
+	select {
+	case databaseContext := <-observedContext:
+		if marker := databaseContext.Value(pinkertonsRequestContextKey{}); marker != pinkertonsRequestContextMarker {
+			t.Errorf("database context marker = %v, want %q", marker, pinkertonsRequestContextMarker)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("database query did not start")
+	}
+}
+
+func TestPinkertonsHandlersPropagateRequestCancellation(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		routeVars map[string]string
+		handler   func(*Server) http.HandlerFunc
+	}{
+		{
+			name: "activities",
+			path: "/pinkertons/activities?limit=1",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.ActivitiesHandler()
+			},
+		},
+		{
+			name:      "activity by ID",
+			path:      "/pinkertons/activities/1",
+			routeVars: map[string]string{"id": "1"},
+			handler: func(server *Server) http.HandlerFunc {
+				return server.ActivityByIDHandler()
+			},
+		},
+		{
+			name: "locations",
+			path: "/pinkertons/locations",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.LocationsHandler()
+			},
+		},
+		{
+			name: "operatives",
+			path: "/pinkertons/operatives",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.OperativesHandler()
+			},
+		},
+		{
+			name: "subjects",
+			path: "/pinkertons/subjects",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.SubjectsHandler()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			observedContext := make(chan context.Context, 1)
+			pool := newPinkertonsCancellationPool(t, observedContext)
+			request, cancel := newPinkertonsRequest(t, tt.path)
+			t.Cleanup(cancel)
+			if tt.routeVars != nil {
+				request = mux.SetURLVars(request, tt.routeVars)
+			}
+
+			response := httptest.NewRecorder()
+			handlerDone := make(chan any, 1)
+			go func() {
+				var panicValue any
+				defer func() {
+					panicValue = recover()
+					handlerDone <- panicValue
+				}()
+				tt.handler(&Server{DB: pool}).ServeHTTP(response, request)
+			}()
+
+			assertPinkertonsDatabaseContext(t, observedContext)
+			cancel()
+
+			select {
+			case panicValue := <-handlerDone:
+				if panicValue != nil {
+					t.Fatalf("handler panicked after cancellation: %v", panicValue)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("handler did not stop after request cancellation")
+			}
+
+			if response.Code != http.StatusInternalServerError {
+				t.Fatalf("status = %d, want %d", response.Code, http.StatusInternalServerError)
+			}
+			if body := strings.TrimSpace(response.Body.String()); body != http.StatusText(http.StatusInternalServerError) {
+				t.Fatalf("body = %q, want %q", body, http.StatusText(http.StatusInternalServerError))
+			}
+		})
+	}
+}
+
+func TestActivityLocationsPropagatesRequestCancellation(t *testing.T) {
+	observedContext := make(chan context.Context, 1)
+	pool := newPinkertonsCancellationPool(t, observedContext)
+	request, cancel := newPinkertonsRequest(t, "/pinkertons/activities?limit=1")
+	t.Cleanup(cancel)
+
+	queryDone := make(chan error, 1)
+	go func() {
+		_, err := (&Server{DB: pool}).activityLocations(request.Context(), 1)
+		queryDone <- err
+	}()
+
+	assertPinkertonsDatabaseContext(t, observedContext)
+	cancel()
+
+	select {
+	case err := <-queryDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("activityLocations error = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("location query did not stop after request cancellation")
+	}
+}


### PR DESCRIPTION
## Summary

- propagate HTTP request contexts through all seven Pinkertons database calls across five handlers
- centralize per-activity location loading so nested queries honor cancellation and return errors consistently
- return generic 500 responses for database, row-scan, and iteration failures instead of partial data
- preserve 404 responses for genuinely missing activities while treating other query failures as 500s
- add cancellation coverage for every Pinkertons handler and the nested location loader
- bound integration-test setup requests without changing production endpoint defaults

## Why

Pinkertons queries used `context.TODO()`, so they could continue after a client disconnected or canceled its request. This was especially risky in `/pinkertons/activities`: a canceled nested location query could be logged and skipped for every remaining activity, producing repeated work and a partial response.

The single-activity handler also reported every database failure as “Activity not found,” masking operational errors as 404s.

Successful response fields, filters, and default limits are unchanged. Pagination and replacement of the N+1 location lookup remain a separate performance change under #100.

## Validation

- `go mod tidy -diff`
- `go test -race . -count=1`
- `go test -race . -run 'Test(PinkertonsHandlersPropagateRequestCancellation|ActivityLocationsPropagatesRequestCancellation)' -count=1`
- `go test ./cmd/apiary -run '^TestDetectives' -count=1 -v` — all 10 live tests passed in 2.45 seconds
- `go build ./...`
- `go vet ./...`
- `go run honnef.co/go/tools/cmd/staticcheck@v0.6.1 ./...`
- `go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...` — no vulnerabilities found

## Consumer impact

Mapping Pinkertons continues to receive the same activity, location, operative, and subject response shapes. This PR does not add pagination or change the unbounded `/pinkertons/activities` contract used by the current map and dashboard.
