### PR TITLE
Coordinate graceful server shutdown

### DIFF
--- a/cmd/apiary/main.go
+++ b/cmd/apiary/main.go
@@ -3,41 +3,30 @@ package main
 import (
 	"context"
 	"log"
-	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	apiary "github.com/chnm/apiary"
+	"github.com/chnm/apiary/internal/lifecycle"
 )
 
+const gracefulShutdownTimeout = 8 * time.Second
+
 func main() {
-
-	var server *apiary.Server
-	// Create a context and listen for signals to gracefully shutdown the application
-	ctx, cancel := context.WithCancel(context.Background())
-	quit := make(chan os.Signal, 1)
-	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
-	// Clean up function that will be called at program end no matter what
-	defer func() {
-		signal.Stop(quit)
-		cancel()
-	}()
-
-	// Listen for shutdown signals in a go-routine and cancel context then
-	go func() {
-		select {
-		case <-quit:
-			log.Println("shutdown signal received, so quitting Apiary")
-			cancel()
-			server.Shutdown()
-		case <-ctx.Done():
-		}
-	}()
-
-	server = apiary.NewServer(ctx)
-	err := server.Run()
-	if err != nil {
-		log.Fatal("error running the server:", err)
+	if err := run(); err != nil {
+		log.Fatal("error running the server: ", err)
 	}
+}
 
+func run() error {
+	ctx, stop := signal.NotifyContext(
+		context.Background(),
+		syscall.SIGINT,
+		syscall.SIGTERM,
+	)
+	defer stop()
+
+	server := apiary.NewServer(ctx)
+	return lifecycle.Run(ctx, server, gracefulShutdownTimeout)
 }

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -1,0 +1,59 @@
+// Package lifecycle coordinates server startup and graceful shutdown.
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Server is the lifecycle surface required by Run.
+type Server interface {
+	Run() error
+	Shutdown(context.Context) error
+}
+
+// Run starts server and blocks until it exits or ctx is canceled. On
+// cancellation, Run waits for graceful shutdown and for the serving goroutine
+// to finish before returning.
+func Run(
+	ctx context.Context,
+	server Server,
+	shutdownTimeout time.Duration,
+) error {
+	if shutdownTimeout <= 0 {
+		return errors.New("shutdown timeout must be positive")
+	}
+
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- server.Run()
+	}()
+
+	select {
+	case err := <-runErr:
+		return err
+	case <-ctx.Done():
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(
+		context.Background(),
+		shutdownTimeout,
+	)
+	defer cancel()
+
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		return fmt.Errorf("gracefully shut down server: %w", err)
+	}
+
+	select {
+	case err := <-runErr:
+		return err
+	case <-shutdownCtx.Done():
+		return fmt.Errorf(
+			"wait for server to stop: %w",
+			shutdownCtx.Err(),
+		)
+	}
+}

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -1,0 +1,123 @@
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type fakeServer struct {
+	runStarted       chan struct{}
+	runFinished      chan struct{}
+	runErr           error
+	shutdownCalled   atomic.Bool
+	shutdownBehavior func(context.Context) error
+}
+
+func newFakeServer() *fakeServer {
+	return &fakeServer{
+		runStarted:  make(chan struct{}),
+		runFinished: make(chan struct{}),
+	}
+}
+
+func (server *fakeServer) Run() error {
+	close(server.runStarted)
+	<-server.runFinished
+	return server.runErr
+}
+
+func (server *fakeServer) Shutdown(ctx context.Context) error {
+	server.shutdownCalled.Store(true)
+	if server.shutdownBehavior != nil {
+		return server.shutdownBehavior(ctx)
+	}
+	close(server.runFinished)
+	return nil
+}
+
+func TestRunShutsDownAfterImmediateCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	server := newFakeServer()
+
+	if err := Run(ctx, server, time.Second); err != nil {
+		t.Fatalf("Run returned an error: %v", err)
+	}
+	if !server.shutdownCalled.Load() {
+		t.Fatal("Shutdown was not called")
+	}
+}
+
+func TestRunReturnsServerErrorWithoutShutdown(t *testing.T) {
+	wantErr := errors.New("listener failed")
+	server := newFakeServer()
+	server.runErr = wantErr
+	close(server.runFinished)
+
+	err := Run(context.Background(), server, time.Second)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Run error = %v, want %v", err, wantErr)
+	}
+	if server.shutdownCalled.Load() {
+		t.Fatal("Shutdown was called after the server had already stopped")
+	}
+}
+
+func TestRunWaitsForShutdownAndServingGoroutine(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	server := newFakeServer()
+	shutdownRelease := make(chan struct{})
+	server.shutdownBehavior = func(context.Context) error {
+		<-shutdownRelease
+		close(server.runFinished)
+		return nil
+	}
+
+	result := make(chan error, 1)
+	go func() {
+		result <- Run(ctx, server, time.Second)
+	}()
+
+	<-server.runStarted
+	cancel()
+
+	select {
+	case err := <-result:
+		t.Fatalf("Run returned before shutdown completed: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(shutdownRelease)
+	if err := <-result; err != nil {
+		t.Fatalf("Run returned an error: %v", err)
+	}
+}
+
+func TestRunBoundsGracefulShutdown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	server := newFakeServer()
+	server.shutdownBehavior = func(ctx context.Context) error {
+		<-ctx.Done()
+		close(server.runFinished)
+		return ctx.Err()
+	}
+
+	cancel()
+	err := Run(ctx, server, 20*time.Millisecond)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf(
+			"Run error = %v, want context.DeadlineExceeded",
+			err,
+		)
+	}
+}
+
+func TestRunRejectsNonPositiveShutdownTimeout(t *testing.T) {
+	err := Run(context.Background(), newFakeServer(), 0)
+	if err == nil {
+		t.Fatal("Run returned nil for a non-positive shutdown timeout")
+	}
+}

--- a/server.go
+++ b/server.go
@@ -2,6 +2,7 @@ package apiary
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"math"
 	"net/http"
@@ -98,13 +99,15 @@ func (s *Server) Run() error {
 	return err
 }
 
-// Shutdown closes the connection to the database and shutsdown the server.
-func (s *Server) Shutdown() {
+// Shutdown stops accepting requests, drains active requests, and then closes
+// the database connection pool.
+func (s *Server) Shutdown(ctx context.Context) error {
+	log.Println("shutting down the web server")
+	if err := s.Server.Shutdown(ctx); err != nil {
+		return fmt.Errorf("shut down HTTP server: %w", err)
+	}
+
 	log.Println("closing the connection to the database")
 	s.DB.Close()
-	log.Println("shutting down the web server")
-	err := s.Server.Shutdown(context.TODO())
-	if err != nil {
-		log.Println("error shutting down web server:", err)
-	}
+	return nil
 }

--- a/server_shutdown_test.go
+++ b/server_shutdown_test.go
@@ -1,0 +1,82 @@
+package apiary
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestServerShutdownWaitsForActiveRequests(t *testing.T) {
+	handlerStarted := make(chan struct{})
+	releaseHandler := make(chan struct{})
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(handlerStarted)
+		<-releaseHandler
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	httpServer := httptest.NewServer(handler)
+	t.Cleanup(httpServer.Close)
+
+	pool, err := pgxpool.New(
+		context.Background(),
+		"postgres://apiary:apiary@127.0.0.1:1/apiary",
+	)
+	if err != nil {
+		t.Fatalf("create database pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	server := &Server{
+		Server: httpServer.Config,
+		DB:     pool,
+	}
+
+	requestDone := make(chan error, 1)
+	go func() {
+		response, err := http.Get(httpServer.URL)
+		if err == nil {
+			defer response.Body.Close()
+			if response.StatusCode != http.StatusNoContent {
+				err = fmt.Errorf(
+					"response status = %d, want %d",
+					response.StatusCode,
+					http.StatusNoContent,
+				)
+			}
+		}
+		requestDone <- err
+	}()
+
+	<-handlerStarted
+	shutdownDone := make(chan error, 1)
+	go func() {
+		shutdownDone <- server.Shutdown(context.Background())
+	}()
+
+	returnedEarly := false
+	select {
+	case err := <-shutdownDone:
+		returnedEarly = true
+		if err != nil {
+			t.Errorf("Shutdown returned an error: %v", err)
+		}
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(releaseHandler)
+	if err := <-requestDone; err != nil {
+		t.Fatalf("active request failed during shutdown: %v", err)
+	}
+	if returnedEarly {
+		t.Fatal("Shutdown returned before the active request completed")
+	}
+	if err := <-shutdownDone; err != nil {
+		t.Fatalf("Shutdown returned an error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- replace the shared signal channel and uninitialized server pointer with `signal.NotifyContext`
- run the listener separately while the main lifecycle waits synchronously for graceful shutdown
- bound shutdown to eight seconds so it fits within the current ten-second Docker Compose grace period
- drain active HTTP requests before closing the database pool
- wait for both graceful shutdown and the serving goroutine before the process exits

## Root cause

The signal goroutine captured `server` before `NewServer` assigned it, creating a data race and a possible nil dereference when a signal arrived during initialization.

The same goroutine called `http.Server.Shutdown` while the main goroutine was blocked in `ListenAndServe`. Because `Shutdown` makes `ListenAndServe` return immediately, the main goroutine could exit before active requests finished draining. The database was also closed before the HTTP server stopped accepting and draining requests, and the unbounded `context.TODO()` shutdown could hang indefinitely.

## Impact

`SIGINT` and `SIGTERM` now initiate a bounded, ordered shutdown:

1. stop accepting new HTTP requests
2. wait up to eight seconds for active requests
3. close the database pool
4. wait for the serving goroutine to finish
5. exit cleanly

No Dockerfile change is required because the image already uses an exec-form `CMD`, so signals reach the Apiary process directly.

The eight-second limit is safe under the current Compose default. A future systems change can set `stop_grace_period: 30s`; after that, Apiary's application window can be raised to approximately 20 seconds.

Closes #75.

## Verification

- `go test -race ./internal/lifecycle . -count=1`
- `go build ./...`
- `go vet ./...`
- `go mod verify`
- `go mod tidy -diff`
- `go test -run '^$' ./db`
- `go run honnef.co/go/tools/cmd/staticcheck@v0.6.1 ./...`
- `go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...`
- process-level signal smoke test against the configured database
- live request completed before a clean signal-driven exit with status 0
