### PR TITLE
Add Pinkertons offset pagination

### DIFF
--- a/cmd/apiary/pinkertons_test.go
+++ b/cmd/apiary/pinkertons_test.go
@@ -79,6 +79,64 @@ func TestDetectivesActivitiesUsesTwoQueries(t *testing.T) {
 	}
 }
 
+func TestDetectivesActivitiesOffsetPagination(t *testing.T) {
+	fetchActivities := func(path string) []apiary.Activity {
+		t.Helper()
+
+		req, err := http.NewRequest(http.MethodGet, path, nil)
+		if err != nil {
+			t.Fatalf("Create request: %v", err)
+		}
+		response := executeRequest(req)
+		checkResponseCode(t, http.StatusOK, response.Code)
+
+		var activities []apiary.Activity
+		if err := json.Unmarshal(response.Body.Bytes(), &activities); err != nil {
+			t.Fatalf("Unmarshal response: %v", err)
+		}
+		return activities
+	}
+
+	firstTwo := fetchActivities("/pinkertons/activities?limit=2&offset=0")
+	if len(firstTwo) != 2 {
+		t.Fatalf("First page length = %d, want 2", len(firstTwo))
+	}
+
+	secondActivity := fetchActivities(
+		"/pinkertons/activities?limit=1&offset=1",
+	)
+	if len(secondActivity) != 1 {
+		t.Fatalf("Second page length = %d, want 1", len(secondActivity))
+	}
+	if secondActivity[0].ID != firstTwo[1].ID {
+		t.Fatalf(
+			"Offset activity ID = %d, want %d",
+			secondActivity[0].ID,
+			firstTwo[1].ID,
+		)
+	}
+
+	var locationID int
+	for _, activity := range firstTwo {
+		if len(activity.Locations) > 0 {
+			locationID = activity.Locations[0].ID
+			break
+		}
+	}
+	if locationID == 0 {
+		t.Fatal("First page has no location to test filtered pagination")
+	}
+
+	filteredPage := fetchActivities(
+		"/pinkertons/activities?location_id=" +
+			strconv.Itoa(locationID) +
+			"&limit=1&offset=0",
+	)
+	if len(filteredPage) != 1 {
+		t.Fatalf("Filtered page length = %d, want 1", len(filteredPage))
+	}
+}
+
 func TestDetectivesActivitiesWithLocations(t *testing.T) {
 	// Check that we get activities with locations included
 	req, _ := http.NewRequest("GET", "/pinkertons/activities?include_locations=true&limit=10", nil)

--- a/endpoints.go
+++ b/endpoints.go
@@ -346,6 +346,10 @@ func (s *Server) EndpointsHandler() http.HandlerFunc {
 						"First 10 activities with location coordinates",
 					},
 					{
+						baseurl + "/pinkertons/activities?limit=10&offset=10",
+						"Next 10 activities with location coordinates",
+					},
+					{
 						baseurl + "/pinkertons/activities?operative=John+Doe",
 						"Follow a specific operative",
 					},

--- a/pinkertons.go
+++ b/pinkertons.go
@@ -220,6 +220,7 @@ func (v *NullFloat64) Scan(value interface{}) error {
 //   - end_date: filter by end date (YYYY-MM-DD)
 //   - location_id: filter by location ID
 //   - limit: maximum number of results to return (default: no limit)
+//   - offset: number of ordered results to skip (default: 0)
 func (s *Server) ActivitiesHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		operative := r.URL.Query().Get("operative")
@@ -228,6 +229,7 @@ func (s *Server) ActivitiesHandler() http.HandlerFunc {
 		endDate := r.URL.Query().Get("end_date")
 		locationIDStr := r.URL.Query().Get("location_id")
 		limitStr := r.URL.Query().Get("limit")
+		offsetStr := r.URL.Query().Get("offset")
 
 		// Build query dynamically based on parameters
 		baseQuery := `
@@ -278,7 +280,7 @@ func (s *Server) ActivitiesHandler() http.HandlerFunc {
 			argCount++
 		}
 
-		baseQuery += " ORDER BY a.date, a.time"
+		baseQuery += " ORDER BY a.date, a.time, a.id"
 
 		// Add limit if specified
 		if limitStr != "" {
@@ -289,6 +291,18 @@ func (s *Server) ActivitiesHandler() http.HandlerFunc {
 			}
 			baseQuery += fmt.Sprintf(" LIMIT $%d", argCount)
 			args = append(args, limit)
+			argCount++
+		}
+
+		// Add offset if specified
+		if offsetStr != "" {
+			offset, err := strconv.Atoi(offsetStr)
+			if err != nil || offset < 0 {
+				http.Error(w, "Invalid offset parameter", http.StatusBadRequest)
+				return
+			}
+			baseQuery += fmt.Sprintf(" OFFSET $%d", argCount)
+			args = append(args, offset)
 		}
 
 		baseQuery += ";"

--- a/pinkertons_pagination_test.go
+++ b/pinkertons_pagination_test.go
@@ -1,0 +1,57 @@
+package apiary
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestActivitiesRejectInvalidPaginationParameters(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		body string
+	}{
+		{
+			name: "zero limit",
+			path: "/pinkertons/activities?limit=0",
+			body: "Invalid limit parameter",
+		},
+		{
+			name: "non-numeric limit",
+			path: "/pinkertons/activities?limit=ten",
+			body: "Invalid limit parameter",
+		},
+		{
+			name: "negative offset",
+			path: "/pinkertons/activities?offset=-1",
+			body: "Invalid offset parameter",
+		},
+		{
+			name: "non-numeric offset",
+			path: "/pinkertons/activities?offset=ten",
+			body: "Invalid offset parameter",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			response := httptest.NewRecorder()
+
+			(&Server{}).ActivitiesHandler().ServeHTTP(response, request)
+
+			if response.Code != http.StatusBadRequest {
+				t.Fatalf(
+					"status = %d, want %d",
+					response.Code,
+					http.StatusBadRequest,
+				)
+			}
+			if body := strings.TrimSpace(response.Body.String()); body != tt.body {
+				t.Fatalf("body = %q, want %q", body, tt.body)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add optional, parameterized `offset` support to the Pinkertons activities endpoint
- make pagination deterministic with `ORDER BY a.date, a.time, a.id`
- reject invalid limits and offsets with `400 Bad Request`
- document an offset-pagination example in the endpoint index
- cover both unfiltered and `location_id`-filtered pagination

## Rollout

This is the backward-compatible first step of the Pinkertons payload work tracked in #100. It does **not** add a default limit, so existing consumers continue to receive the full result set.

After this change is deployed, Mapping Pinkertons can switch its five activity fetches to a shared paginated loader. A server-side default limit can then be considered separately after that consumer change is deployed.

The current 1,823-row dataset was also smoke-tested in 500-row pages. The pages contained 500, 500, 500, and 323 rows; their concatenated IDs were unique and exactly matched the unbounded response in the same order.

## Verification

- `go test -race . -count=1`
- `go test ./cmd/apiary -run '^TestDetectivesActivitiesOffsetPagination$' -count=1 -v`
- `go build ./...`
- `go vet ./...`
- `go mod tidy -diff`
- `git diff --check`
