### PR TITLE
Add Pinkertons default activity limit

### DIFF
--- a/cmd/apiary/pinkertons_test.go
+++ b/cmd/apiary/pinkertons_test.go
@@ -34,6 +34,23 @@ func (*pinkertonsQueryCounter) TraceQueryEnd(
 ) {
 }
 
+func fetchDetectiveActivities(t *testing.T, path string) []apiary.Activity {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodGet, path, nil)
+	if err != nil {
+		t.Fatalf("Create request: %v", err)
+	}
+	response := executeRequest(req)
+	checkResponseCode(t, http.StatusOK, response.Code)
+
+	var activities []apiary.Activity
+	if err := json.Unmarshal(response.Body.Bytes(), &activities); err != nil {
+		t.Fatalf("Unmarshal response: %v", err)
+	}
+	return activities
+}
+
 func TestDetectivesActivities(t *testing.T) {
 	// Check that we get the right response
 	req, _ := http.NewRequest("GET", "/pinkertons/activities?limit=10", nil)
@@ -50,6 +67,42 @@ func TestDetectivesActivities(t *testing.T) {
 	// Check that we got an array (even if empty)
 	if data == nil {
 		t.Error("Expected array of activities, got nil")
+	}
+}
+
+func TestDetectivesActivitiesDefaultLimit(t *testing.T) {
+	const defaultLimit = 500
+
+	defaultPage := fetchDetectiveActivities(t, "/pinkertons/activities")
+	if len(defaultPage) != defaultLimit {
+		t.Fatalf(
+			"Default page length = %d, want %d",
+			len(defaultPage),
+			defaultLimit,
+		)
+	}
+
+	explicitPage := fetchDetectiveActivities(
+		t,
+		"/pinkertons/activities?limit=501",
+	)
+	if len(explicitPage) != defaultLimit+1 {
+		t.Fatalf(
+			"Explicit page length = %d, want %d",
+			len(explicitPage),
+			defaultLimit+1,
+		)
+	}
+
+	for index := range defaultPage {
+		if defaultPage[index].ID != explicitPage[index].ID {
+			t.Fatalf(
+				"Default page activity %d ID = %d, want %d",
+				index,
+				defaultPage[index].ID,
+				explicitPage[index].ID,
+			)
+		}
 	}
 }
 
@@ -80,29 +133,16 @@ func TestDetectivesActivitiesUsesTwoQueries(t *testing.T) {
 }
 
 func TestDetectivesActivitiesOffsetPagination(t *testing.T) {
-	fetchActivities := func(path string) []apiary.Activity {
-		t.Helper()
-
-		req, err := http.NewRequest(http.MethodGet, path, nil)
-		if err != nil {
-			t.Fatalf("Create request: %v", err)
-		}
-		response := executeRequest(req)
-		checkResponseCode(t, http.StatusOK, response.Code)
-
-		var activities []apiary.Activity
-		if err := json.Unmarshal(response.Body.Bytes(), &activities); err != nil {
-			t.Fatalf("Unmarshal response: %v", err)
-		}
-		return activities
-	}
-
-	firstTwo := fetchActivities("/pinkertons/activities?limit=2&offset=0")
+	firstTwo := fetchDetectiveActivities(
+		t,
+		"/pinkertons/activities?limit=2&offset=0",
+	)
 	if len(firstTwo) != 2 {
 		t.Fatalf("First page length = %d, want 2", len(firstTwo))
 	}
 
-	secondActivity := fetchActivities(
+	secondActivity := fetchDetectiveActivities(
+		t,
 		"/pinkertons/activities?limit=1&offset=1",
 	)
 	if len(secondActivity) != 1 {
@@ -127,9 +167,10 @@ func TestDetectivesActivitiesOffsetPagination(t *testing.T) {
 		t.Fatal("First page has no location to test filtered pagination")
 	}
 
-	filteredPage := fetchActivities(
-		"/pinkertons/activities?location_id=" +
-			strconv.Itoa(locationID) +
+	filteredPage := fetchDetectiveActivities(
+		t,
+		"/pinkertons/activities?location_id="+
+			strconv.Itoa(locationID)+
 			"&limit=1&offset=0",
 	)
 	if len(filteredPage) != 1 {

--- a/endpoints.go
+++ b/endpoints.go
@@ -338,7 +338,7 @@ func (s *Server) EndpointsHandler() http.HandlerFunc {
 				},
 			},
 			{
-				"Pinkertons: All activities",
+				"Pinkertons: Activities (first 500 by default)",
 				baseurl + "/pinkertons/activities",
 				[]ExampleURL{
 					{

--- a/pinkertons.go
+++ b/pinkertons.go
@@ -66,6 +66,8 @@ INNER JOIN detectives.activity_locations al ON l.id = al.location_id
 WHERE al.activity_id = ANY($1);
 `
 
+const defaultActivitiesLimit = 500
+
 func (s *Server) activityLocations(ctx context.Context, activityID int) ([]Location, error) {
 	locations := make([]Location, 0)
 	rows, err := s.DB.Query(ctx, activityLocationsQuery, activityID)
@@ -212,14 +214,14 @@ func (v *NullFloat64) Scan(value interface{}) error {
 	return nil
 }
 
-// ActivitiesHandler returns a list of all detective activities with location data and optional filtering
+// ActivitiesHandler returns detective activities with location data and optional filtering.
 // Query parameters:
 //   - operative: filter by operative name
 //   - subject: filter by subject name
 //   - start_date: filter by start date (YYYY-MM-DD)
 //   - end_date: filter by end date (YYYY-MM-DD)
 //   - location_id: filter by location ID
-//   - limit: maximum number of results to return (default: no limit)
+//   - limit: maximum number of results to return (default: 500)
 //   - offset: number of ordered results to skip (default: 0)
 func (s *Server) ActivitiesHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -282,17 +284,18 @@ func (s *Server) ActivitiesHandler() http.HandlerFunc {
 
 		baseQuery += " ORDER BY a.date, a.time, a.id"
 
-		// Add limit if specified
+		limit := defaultActivitiesLimit
 		if limitStr != "" {
-			limit, err := strconv.Atoi(limitStr)
+			var err error
+			limit, err = strconv.Atoi(limitStr)
 			if err != nil || limit <= 0 {
 				http.Error(w, "Invalid limit parameter", http.StatusBadRequest)
 				return
 			}
-			baseQuery += fmt.Sprintf(" LIMIT $%d", argCount)
-			args = append(args, limit)
-			argCount++
 		}
+		baseQuery += fmt.Sprintf(" LIMIT $%d", argCount)
+		args = append(args, limit)
+		argCount++
 
 		// Add offset if specified
 		if offsetStr != "" {


### PR DESCRIPTION
## Summary

- default `/pinkertons/activities` responses to 500 ordered activities when `limit` is omitted
- continue honoring any valid explicit `limit`, including values above 500
- document the new default in the handler and endpoint index
- add live integration coverage for the default, explicit override, and stable ordering

## Rollout context

This completes the staged Pinkertons pagination work tracked in #100:

1. #112 added deterministic `limit`/`offset` pagination without changing existing responses.
2. [chnm/mapping-pinkertons#10](https://github.com/chnm/mapping-pinkertons/pull/10) moved all five known consumers to a shared 500-row pager and is deployed.
3. This PR now makes bounded responses the default for callers that omit `limit`.

The deployed Mapping Pinkertons helper and all five production pages were verified after deployment. The helper still assembles all 1,823 unique activities and preserves all 52 matches for a tested `location_id` filter.

## User impact

Callers that currently omit `limit` will receive the first 500 activities in deterministic `date`, `time`, and `id` order. They can page with `offset` or request a different positive `limit`.

## Verification

- `go test -race . -count=1`
- `go test ./cmd/apiary -run '^TestDetectivesActivities(DefaultLimit|OffsetPagination)$' -count=1 -v`
- `go build ./...`
- `go vet ./...`
- `go mod tidy -diff`
- `staticcheck ./...` (2026.1 / v0.7.0)
- `govulncheck ./...` (v1.6.0: no vulnerabilities)
- `git diff --check`
