### PR TITLE
Propagate AHCb request contexts

### DIFF
--- a/ahcb.go
+++ b/ahcb.go
@@ -1,7 +1,6 @@
 package apiary
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -53,10 +52,11 @@ func (s *Server) AHCBStatesHandler() http.HandlerFunc {
 		}
 
 		var result string // result will be a string containing GeoJSON
-		err = s.DB.QueryRow(context.TODO(), query, date).Scan(&result)
+		err = s.DB.QueryRow(r.Context(), query, date).Scan(&result)
 		if err != nil {
 			log.Println(err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -101,10 +101,11 @@ func (s *Server) AHCBCountiesHandler() http.HandlerFunc {
 			return
 		}
 		var result string
-		err = s.DB.QueryRow(context.TODO(), query, date).Scan(&result)
+		err = s.DB.QueryRow(r.Context(), query, date).Scan(&result)
 		if err != nil {
 			log.Println(err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, result)
@@ -152,10 +153,11 @@ func (s *Server) AHCBCountiesByIDHandler() http.HandlerFunc {
 
 		// ids := pq.Array(strings.Split(params["id"], ","))
 		ids := strings.Split(params["id"], ",")
-		err = s.DB.QueryRow(context.TODO(), query, date, ids).Scan(&result)
+		err = s.DB.QueryRow(r.Context(), query, date, ids).Scan(&result)
 		if err != nil {
 			log.Println(err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, result)
@@ -202,10 +204,11 @@ func (s *Server) AHCBCountiesByStateTerrIDHandler() http.HandlerFunc {
 		var result string
 		// stateTerrIds := pq.Array(strings.Split(params["state-terr-id"], ","))
 		stateTerrIds := strings.Split(params["state-terr-id"], ",")
-		err = s.DB.QueryRow(context.TODO(), query, date, stateTerrIds).Scan(&result)
+		err = s.DB.QueryRow(r.Context(), query, date, stateTerrIds).Scan(&result)
 		if err != nil {
 			log.Println(err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, result)
@@ -252,10 +255,11 @@ func (s *Server) AHCBCountiesByStateCodeHandler() http.HandlerFunc {
 		var result string
 		// stateCodes := pq.Array(strings.Split(params["state-code"], ","))
 		stateCodes := strings.Split(params["state-code"], ",")
-		err = s.DB.QueryRow(context.TODO(), query, date, stateCodes).Scan(&result)
+		err = s.DB.QueryRow(r.Context(), query, date, stateCodes).Scan(&result)
 		if err != nil {
 			log.Println(err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, result)

--- a/ahcb_context_test.go
+++ b/ahcb_context_test.go
@@ -1,0 +1,167 @@
+package apiary
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type ahcbRequestContextKey struct{}
+
+const ahcbRequestContextMarker = "ahcb-request-context"
+
+func TestAHCBHandlersPropagateRequestCancellation(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		routeVars map[string]string
+		handler   func(*Server) http.HandlerFunc
+	}{
+		{
+			name:      "states",
+			path:      "/ahcb/states/1789-07-04/",
+			routeVars: map[string]string{"date": "1789-07-04"},
+			handler: func(server *Server) http.HandlerFunc {
+				return server.AHCBStatesHandler()
+			},
+		},
+		{
+			name:      "counties",
+			path:      "/ahcb/counties/1926-07-04/",
+			routeVars: map[string]string{"date": "1926-07-04"},
+			handler: func(server *Server) http.HandlerFunc {
+				return server.AHCBCountiesHandler()
+			},
+		},
+		{
+			name: "counties by ID",
+			path: "/ahcb/counties/1980-12-31/id/vas_fairfax,vas_arlington/",
+			routeVars: map[string]string{
+				"date": "1980-12-31",
+				"id":   "vas_fairfax,vas_arlington",
+			},
+			handler: func(server *Server) http.HandlerFunc {
+				return server.AHCBCountiesByIDHandler()
+			},
+		},
+		{
+			name: "counties by state territory ID",
+			path: "/ahcb/counties/1980-12-31/state-terr-id/ga_state,va_state/",
+			routeVars: map[string]string{
+				"date":          "1980-12-31",
+				"state-terr-id": "ga_state,va_state",
+			},
+			handler: func(server *Server) http.HandlerFunc {
+				return server.AHCBCountiesByStateTerrIDHandler()
+			},
+		},
+		{
+			name: "counties by state code",
+			path: "/ahcb/counties/1940-12-31/state-code/nd,sd/",
+			routeVars: map[string]string{
+				"date":       "1940-12-31",
+				"state-code": "nd,sd",
+			},
+			handler: func(server *Server) http.HandlerFunc {
+				return server.AHCBCountiesByStateCodeHandler()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			observedContext := make(chan context.Context, 1)
+			config, err := pgxpool.ParseConfig(
+				"postgres://apiary:apiary@127.0.0.1:1/apiary",
+			)
+			if err != nil {
+				t.Fatalf("parse database config: %v", err)
+			}
+			config.BeforeConnect = func(ctx context.Context, _ *pgx.ConnConfig) error {
+				observedContext <- ctx
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(2 * time.Second):
+					return errors.New("database context was not canceled")
+				}
+			}
+
+			pool, err := pgxpool.NewWithConfig(context.Background(), config)
+			if err != nil {
+				t.Fatalf("create database pool: %v", err)
+			}
+			t.Cleanup(pool.Close)
+
+			requestContext := context.WithValue(
+				context.Background(),
+				ahcbRequestContextKey{},
+				ahcbRequestContextMarker,
+			)
+			requestContext, cancel := context.WithCancel(requestContext)
+			t.Cleanup(cancel)
+
+			request := httptest.NewRequest(http.MethodGet, tt.path, nil).
+				WithContext(requestContext)
+			request = mux.SetURLVars(request, tt.routeVars)
+			response := httptest.NewRecorder()
+			handlerDone := make(chan any, 1)
+
+			go func() {
+				var panicValue any
+				defer func() {
+					panicValue = recover()
+					handlerDone <- panicValue
+				}()
+				tt.handler(&Server{DB: pool}).ServeHTTP(response, request)
+			}()
+
+			select {
+			case databaseContext := <-observedContext:
+				if marker := databaseContext.Value(ahcbRequestContextKey{}); marker != ahcbRequestContextMarker {
+					t.Errorf(
+						"database context marker = %v, want %q",
+						marker,
+						ahcbRequestContextMarker,
+					)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("handler did not start a database query")
+			}
+
+			cancel()
+
+			select {
+			case panicValue := <-handlerDone:
+				if panicValue != nil {
+					t.Fatalf("handler panicked after cancellation: %v", panicValue)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("handler did not stop after request cancellation")
+			}
+
+			if response.Code != http.StatusInternalServerError {
+				t.Fatalf(
+					"status = %d, want %d",
+					response.Code,
+					http.StatusInternalServerError,
+				)
+			}
+			if body := strings.TrimSpace(response.Body.String()); body != http.StatusText(http.StatusInternalServerError) {
+				t.Fatalf(
+					"body = %q, want %q",
+					body,
+					http.StatusText(http.StatusInternalServerError),
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- pass each AHCb request context into its database query
- stop processing immediately after a database error instead of attempting to append an empty success response
- add cancellation and generic-error regression coverage for all five AHCb handlers

## Why

The AHCb handlers used `context.TODO()`, so database work continued independently after a client disconnected or canceled its request. They also wrote a 500 response and then continued into the normal JSON response path.

Using `r.Context()` ties query lifetime to request lifetime. The new table-driven coverage proves that each handler:

- passes the request context marker to pgx
- exits promptly when the request is canceled
- does not panic
- returns only the generic `Internal Server Error` response

This advances the remaining request-lifecycle work in #100.

## Covered routes

- states
- counties
- counties by ID
- counties by state/territory ID
- counties by state code

## Verification

- `go test -race . -run '^TestAHCBHandlersPropagateRequestCancellation$' -count=1 -v`
- `go test -race . -count=1`
- `go test ./cmd/apiary -run '^TestAHCB' -count=1 -v`
- `go build ./...`
- `go vet ./...`
- `go mod tidy -diff`
- `staticcheck ./...`
- `govulncheck ./...` (`No vulnerabilities found`)
- `git diff --check`
