### PR TITLE
Propagate Catholic request contexts

### DIFF
--- a/catholic-dioceses.go
+++ b/catholic-dioceses.go
@@ -1,9 +1,7 @@
 package apiary
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
 )
@@ -46,31 +44,43 @@ func (s *Server) CatholicDiocesesHandler() http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		results := make([]CatholicDiocese, 0)
-		var row CatholicDiocese
 
-		rows, err := s.DB.Query(context.TODO(), query)
+		rows, err := s.DB.Query(r.Context(), query)
 		if err != nil {
-			log.Println(err)
+			log.Printf("query Catholic dioceses: %v", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 		defer rows.Close()
+
 		for rows.Next() {
-			err := rows.Scan(&row.City, &row.State, &row.Country, &row.Rite,
+			var row CatholicDiocese
+			if err := rows.Scan(&row.City, &row.State, &row.Country, &row.Rite,
 				&row.YearErected, &row.YearMetropolitan, &row.YearDestroyed,
-				&row.Lon, &row.Lat)
-			if err != nil {
-				log.Println(err)
+				&row.Lon, &row.Lat); err != nil {
+				log.Printf("scan Catholic diocese: %v", err)
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				return
 			}
 			results = append(results, row)
 		}
-		err = rows.Err()
-		if err != nil {
-			log.Println(err)
+		if err := rows.Err(); err != nil {
+			log.Printf("iterate Catholic dioceses: %v", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 
-		response, _ := json.Marshal(results)
+		response, err := json.Marshal(results)
+		if err != nil {
+			log.Printf("marshal Catholic dioceses: %v", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
 
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(response))
+		if _, err := w.Write(response); err != nil {
+			log.Printf("write Catholic dioceses response: %v", err)
+		}
 	}
 
 }
@@ -100,29 +110,41 @@ func (s *Server) CatholicDiocesesPerDecadeHandler() http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		results := make([]CatholicDiocesesPerDecade, 0, 52) // Preallocate slice capacity
-		var row CatholicDiocesesPerDecade
 
-		rows, err := s.DB.Query(context.TODO(), query)
+		rows, err := s.DB.Query(r.Context(), query)
 		if err != nil {
-			log.Println(err)
+			log.Printf("query Catholic dioceses per decade: %v", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 		defer rows.Close()
+
 		for rows.Next() {
-			err := rows.Scan(&row.Decade, &row.Count)
-			if err != nil {
-				log.Println(err)
+			var row CatholicDiocesesPerDecade
+			if err := rows.Scan(&row.Decade, &row.Count); err != nil {
+				log.Printf("scan Catholic dioceses per decade: %v", err)
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				return
 			}
 			results = append(results, row)
 		}
-		err = rows.Err()
-		if err != nil {
-			log.Println(err)
+		if err := rows.Err(); err != nil {
+			log.Printf("iterate Catholic dioceses per decade: %v", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 
-		response, _ := json.Marshal(results)
+		response, err := json.Marshal(results)
+		if err != nil {
+			log.Printf("marshal Catholic dioceses per decade: %v", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
 
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(response))
+		if _, err := w.Write(response); err != nil {
+			log.Printf("write Catholic dioceses per decade response: %v", err)
+		}
 	}
 
 }

--- a/catholic_context_test.go
+++ b/catholic_context_test.go
@@ -1,0 +1,129 @@
+package apiary
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type catholicRequestContextKey struct{}
+
+const catholicRequestContextMarker = "catholic-request-context"
+
+func TestCatholicHandlersPropagateRequestCancellation(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		handler func(*Server) http.HandlerFunc
+	}{
+		{
+			name: "dioceses",
+			path: "/catholic-dioceses/",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.CatholicDiocesesHandler()
+			},
+		},
+		{
+			name: "dioceses per decade",
+			path: "/catholic-dioceses/per-decade/",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.CatholicDiocesesPerDecadeHandler()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			observedContext := make(chan context.Context, 1)
+			config, err := pgxpool.ParseConfig(
+				"postgres://apiary:apiary@127.0.0.1:1/apiary",
+			)
+			if err != nil {
+				t.Fatalf("parse database config: %v", err)
+			}
+			config.BeforeConnect = func(ctx context.Context, _ *pgx.ConnConfig) error {
+				observedContext <- ctx
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(2 * time.Second):
+					return errors.New("database context was not canceled")
+				}
+			}
+
+			pool, err := pgxpool.NewWithConfig(context.Background(), config)
+			if err != nil {
+				t.Fatalf("create database pool: %v", err)
+			}
+			t.Cleanup(pool.Close)
+
+			requestContext := context.WithValue(
+				context.Background(),
+				catholicRequestContextKey{},
+				catholicRequestContextMarker,
+			)
+			requestContext, cancel := context.WithCancel(requestContext)
+			t.Cleanup(cancel)
+
+			request := httptest.NewRequest(http.MethodGet, tt.path, nil).
+				WithContext(requestContext)
+			response := httptest.NewRecorder()
+			handlerDone := make(chan any, 1)
+
+			go func() {
+				var panicValue any
+				defer func() {
+					panicValue = recover()
+					handlerDone <- panicValue
+				}()
+				tt.handler(&Server{DB: pool}).ServeHTTP(response, request)
+			}()
+
+			select {
+			case databaseContext := <-observedContext:
+				if marker := databaseContext.Value(catholicRequestContextKey{}); marker != catholicRequestContextMarker {
+					t.Errorf(
+						"database context marker = %v, want %q",
+						marker,
+						catholicRequestContextMarker,
+					)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("handler did not start a database query")
+			}
+
+			cancel()
+
+			select {
+			case panicValue := <-handlerDone:
+				if panicValue != nil {
+					t.Fatalf("handler panicked after cancellation: %v", panicValue)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("handler did not stop after request cancellation")
+			}
+
+			if response.Code != http.StatusInternalServerError {
+				t.Fatalf(
+					"status = %d, want %d",
+					response.Code,
+					http.StatusInternalServerError,
+				)
+			}
+			if body := strings.TrimSpace(response.Body.String()); body != http.StatusText(http.StatusInternalServerError) {
+				t.Fatalf(
+					"body = %q, want %q",
+					body,
+					http.StatusText(http.StatusInternalServerError),
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed

- pass each Catholic Diocese HTTP request context into its database query
- return a generic `500 Internal Server Error` when query, scan, iteration, or
  JSON marshaling fails
- avoid closing a nil row set after a query failure
- keep row values local to each iteration
- add table-driven regression coverage for cancellation propagation and
  query-error behavior in both Catholic handlers

## Why

Both handlers used `context.TODO()`, so database work continued independently of
request cancellation. They also logged query failures and continued to
`defer rows.Close()`, which could panic when `rows` was nil.

Using `r.Context()` lets PostgreSQL work stop when the client disconnects or the
server cancels the request. Returning immediately on database errors prevents
panics and avoids emitting a misleading successful response.

Successful endpoint routes and JSON response shapes are unchanged.

## Validation

- `go test -race . -run '^TestCatholicHandlersPropagateRequestCancellation$' -count=1 -v`
- `go test -race . -count=1`
- `go test ./cmd/apiary -run '^TestCatholic' -count=1 -v`
- `go build ./...`
- `go vet ./...`
- `go mod tidy -diff`
- `staticcheck ./...`
- `govulncheck ./...`
- `git diff --check`

Refs #100
