### PR TITLE
Propagate remaining request contexts

### DIFF
--- a/cmd/apiary/pop_places_test.go
+++ b/cmd/apiary/pop_places_test.go
@@ -70,3 +70,9 @@ func TestPlace(t *testing.T) {
 	}
 
 }
+
+func TestPlaceNotFound(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/pop-places/place/2147483647/", nil)
+	response := executeRequest(req)
+	checkResponseCode(t, http.StatusNotFound, response.Code)
+}

--- a/cmd/apiary/relcensus_test.go
+++ b/cmd/apiary/relcensus_test.go
@@ -96,3 +96,17 @@ func TestRelCensusCityAggregates(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestRelCensusLocations(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/relcensus/cities", nil)
+	response := executeRequest(req)
+	checkResponseCode(t, http.StatusOK, response.Code)
+
+	var data []apiary.LocationInfo
+	if err := json.Unmarshal(response.Body.Bytes(), &data); err != nil {
+		t.Fatal(err)
+	}
+	if len(data) == 0 {
+		t.Fatal("expected Religious Census locations")
+	}
+}

--- a/ne-globe.go
+++ b/ne-globe.go
@@ -1,7 +1,6 @@
 package apiary
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -41,7 +40,7 @@ func (s *Server) NaturalEarthHandler() http.HandlerFunc {
 
 		// If no location is provided, return all countries.
 		if len(location) == 0 {
-			err := s.DB.QueryRow(context.Background(), query).Scan(&result)
+			err := s.DB.QueryRow(r.Context(), query).Scan(&result)
 			if err != nil {
 				log.Println(err)
 				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -73,7 +72,7 @@ func (s *Server) NaturalEarthHandler() http.HandlerFunc {
 			) AS countries;
 		`
 
-		err := s.DB.QueryRow(context.Background(), query, location).Scan(&result)
+		err := s.DB.QueryRow(r.Context(), query, location).Scan(&result)
 		if err != nil {
 			log.Println(err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)

--- a/populated-places.go
+++ b/populated-places.go
@@ -1,9 +1,8 @@
 package apiary
 
 import (
-	"context"
-	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -11,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
+	"github.com/jackc/pgx/v5"
 )
 
 // This file creates a series of endpoints to return all possible names for
@@ -56,30 +56,41 @@ func (s *Server) CountiesInState() http.HandlerFunc {
 		state = strings.ToUpper(state)
 
 		results := make([]PlaceCounty, 0)
-		var row PlaceCounty
 
-		rows, err := s.DB.Query(context.TODO(), query, state)
+		rows, err := s.DB.Query(r.Context(), query, state)
 		if err != nil {
-			log.Println(err)
+			log.Printf("query populated-place counties: %v", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 		defer rows.Close()
+
 		for rows.Next() {
-			err := rows.Scan(&row.CountyAHCB, &row.County)
-			if err != nil {
-				log.Println(err)
+			var row PlaceCounty
+			if err := rows.Scan(&row.CountyAHCB, &row.County); err != nil {
+				log.Printf("scan populated-place county: %v", err)
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				return
 			}
 			results = append(results, row)
 		}
-		err = rows.Err()
-		if err != nil {
-			log.Println(err)
+		if err := rows.Err(); err != nil {
+			log.Printf("iterate populated-place counties: %v", err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 
-		response, _ := json.Marshal(results)
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(response))
+		response, err := json.Marshal(results)
+		if err != nil {
+			log.Printf("marshal populated-place counties: %v", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
 
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write(response); err != nil {
+			log.Printf("write populated-place counties response: %v", err)
+		}
 	}
 }
 
@@ -99,30 +110,41 @@ func (s *Server) PlacesInCounty() http.HandlerFunc {
 		county = strings.ToLower(county)
 
 		results := make([]Place, 0)
-		var row Place
 
-		rows, err := s.DB.Query(context.TODO(), query, county)
+		rows, err := s.DB.Query(r.Context(), query, county)
 		if err != nil {
-			log.Println(err)
+			log.Printf("query populated places: %v", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 		defer rows.Close()
+
 		for rows.Next() {
-			err := rows.Scan(&row.PlaceID, &row.Place, &row.MapName)
-			if err != nil {
-				log.Println(err)
+			var row Place
+			if err := rows.Scan(&row.PlaceID, &row.Place, &row.MapName); err != nil {
+				log.Printf("scan populated place: %v", err)
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				return
 			}
 			results = append(results, row)
 		}
-		err = rows.Err()
-		if err != nil {
-			log.Println(err)
+		if err := rows.Err(); err != nil {
+			log.Printf("iterate populated places: %v", err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 
-		response, _ := json.Marshal(results)
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(response))
+		response, err := json.Marshal(results)
+		if err != nil {
+			log.Printf("marshal populated places: %v", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
 
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write(response); err != nil {
+			log.Printf("write populated places response: %v", err)
+		}
 	}
 }
 
@@ -145,20 +167,28 @@ func (s *Server) Place() http.HandlerFunc {
 
 		var result PlaceDetails
 
-		err = s.DB.QueryRow(context.TODO(), query, placeID).Scan(&result.PlaceID, &result.Place,
+		err = s.DB.QueryRow(r.Context(), query, placeID).Scan(&result.PlaceID, &result.Place,
 			&result.MapName, &result.County, &result.CountyAHCB, &result.State)
 		if err != nil {
-			if err == sql.ErrNoRows {
+			if errors.Is(err, pgx.ErrNoRows) {
 				http.Error(w, fmt.Sprintf("Not found: No place with id %v.", placeID), http.StatusNotFound)
 				return
 			}
-			log.Println(err)
+			log.Printf("query populated-place details: %v", err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 
-		response, _ := json.Marshal(result)
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(response))
+		response, err := json.Marshal(result)
+		if err != nil {
+			log.Printf("marshal populated-place details: %v", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
 
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write(response); err != nil {
+			log.Printf("write populated-place details response: %v", err)
+		}
 	}
 }

--- a/presbyterians.go
+++ b/presbyterians.go
@@ -1,9 +1,7 @@
 package apiary
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
 )
@@ -31,29 +29,40 @@ func (s *Server) PresbyteriansHandler() http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		results := make([]PresbyteriansByYear, 0)
-		var row PresbyteriansByYear
 
-		rows, err := s.DB.Query(context.TODO(), query)
+		rows, err := s.DB.Query(r.Context(), query)
 		if err != nil {
-			log.Println(err)
+			log.Printf("query Presbyterian statistics: %v", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 		defer rows.Close()
+
 		for rows.Next() {
-			err := rows.Scan(&row.Year, &row.Members, &row.Churches)
-			if err != nil {
-				log.Println(err)
+			var row PresbyteriansByYear
+			if err := rows.Scan(&row.Year, &row.Members, &row.Churches); err != nil {
+				log.Printf("scan Presbyterian statistics: %v", err)
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				return
 			}
 			results = append(results, row)
-
 		}
-		err = rows.Err()
-		if err != nil {
-			log.Println(err)
+		if err := rows.Err(); err != nil {
+			log.Printf("iterate Presbyterian statistics: %v", err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 
-		response, _ := json.Marshal(results)
+		response, err := json.Marshal(results)
+		if err != nil {
+			log.Printf("marshal Presbyterian statistics: %v", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(response))
+		if _, err := w.Write(response); err != nil {
+			log.Printf("write Presbyterian statistics response: %v", err)
+		}
 	}
 }

--- a/relcensus-denominations.go
+++ b/relcensus-denominations.go
@@ -1,9 +1,7 @@
 package apiary
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
 )
@@ -35,24 +33,28 @@ func (s *Server) RelCensusDenominationFamiliesHandler() http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		results := make([]DenominationFamily, 0)
-		var row DenominationFamily
 
-		rows, err := s.DB.Query(context.TODO(), query)
+		rows, err := s.DB.Query(r.Context(), query)
 		if err != nil {
-			log.Println(err)
+			log.Printf("query Religious Census denomination families: %v", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 		defer rows.Close()
+
 		for rows.Next() {
-			err := rows.Scan(&row.Name)
-			if err != nil {
-				log.Println(err)
+			var row DenominationFamily
+			if err := rows.Scan(&row.Name); err != nil {
+				log.Printf("scan Religious Census denomination family: %v", err)
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				return
 			}
 			results = append(results, row)
 		}
-		err = rows.Err()
-		if err != nil {
-			log.Println(err)
+		if err := rows.Err(); err != nil {
+			log.Printf("iterate Religious Census denomination families: %v", err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 
 		container := struct {
@@ -61,9 +63,17 @@ func (s *Server) RelCensusDenominationFamiliesHandler() http.HandlerFunc {
 			FamilyRelec: results,
 		}
 
-		response, _ := json.Marshal(container)
+		response, err := json.Marshal(container)
+		if err != nil {
+			log.Printf("marshal Religious Census denomination families: %v", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(response))
+		if _, err := w.Write(response); err != nil {
+			log.Printf("write Religious Census denomination families response: %v", err)
+		}
 	}
 }
 
@@ -79,30 +89,47 @@ func (s *Server) RelCensusDenominationsHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		familyRelec := r.URL.Query().Get("family_relec")
 		results := make([]Denomination, 0)
-		var row Denomination
 
-		rows, err := s.DB.Query(context.TODO(), query, familyRelec)
+		rows, err := s.DB.Query(r.Context(), query, familyRelec)
 		if err != nil {
-			log.Println(err)
+			log.Printf("query Religious Census denominations: %v", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 		defer rows.Close()
+
 		for rows.Next() {
-			err := rows.Scan(&row.DenominationID, &row.Name, &row.ShortName, &row.FamilyCensus, &row.FamilyRelec)
-			if err != nil {
-				log.Println(err)
+			var row Denomination
+			if err := rows.Scan(
+				&row.DenominationID,
+				&row.Name,
+				&row.ShortName,
+				&row.FamilyCensus,
+				&row.FamilyRelec,
+			); err != nil {
+				log.Printf("scan Religious Census denomination: %v", err)
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				return
 			}
 			results = append(results, row)
-
 		}
-		err = rows.Err()
-		if err != nil {
-			log.Println(err)
+		if err := rows.Err(); err != nil {
+			log.Printf("iterate Religious Census denominations: %v", err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 
-		response, _ := json.Marshal(results)
+		response, err := json.Marshal(results)
+		if err != nil {
+			log.Printf("marshal Religious Census denominations: %v", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(response))
+		if _, err := w.Write(response); err != nil {
+			log.Printf("write Religious Census denominations response: %v", err)
+		}
 	}
 
 }

--- a/relecensus-cities.go
+++ b/relecensus-cities.go
@@ -1,9 +1,7 @@
 package apiary
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
 	"strconv"
@@ -148,49 +146,58 @@ func (s *Server) RelCensusCityMembershipHandler() http.HandlerFunc {
 		}
 
 		results := make([]CityMembership, 0)
-		var row CityMembership
 		var rows pgx.Rows
 
 		// We've already done the error checking for the call to the API, so we can
 		// just use the right query as necessary.
 		switch {
 		case denomination != "":
-			rows, err = s.DB.Query(context.TODO(), queryDenomination, yearInt, denomination)
+			rows, err = s.DB.Query(r.Context(), queryDenomination, yearInt, denomination)
 		case denominationFamily != "":
-			rows, err = s.DB.Query(context.TODO(), queryFamily, yearInt, denominationFamily)
+			rows, err = s.DB.Query(r.Context(), queryFamily, yearInt, denominationFamily)
 		case denomination == "" && denominationFamily == "":
-			rows, err = s.DB.Query(context.TODO(), queryAll, yearInt)
+			rows, err = s.DB.Query(r.Context(), queryAll, yearInt)
 		}
 		if err != nil {
-			log.Println(err)
+			log.Printf("query Religious Census city membership: %v", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 		defer rows.Close()
 
 		for rows.Next() {
-			err := rows.Scan(
+			var row CityMembership
+			if err := rows.Scan(
 				&row.Year,
 				&row.Group,
 				&row.City, &row.State,
 				&row.Denominations, &row.Churches, &row.Members,
 				&row.Population1926,
-				&row.Lon, &row.Lat)
-			if err != nil {
-				log.Println(err)
-				log.Println(row)
+				&row.Lon, &row.Lat,
+			); err != nil {
+				log.Printf("scan Religious Census city membership: %v", err)
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				return
 			}
 			results = append(results, row)
-
 		}
-		err = rows.Err()
-		if err != nil {
-			log.Println(err)
+		if err := rows.Err(); err != nil {
+			log.Printf("iterate Religious Census city membership: %v", err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
 
-		response, _ := json.Marshal(results)
+		response, err := json.Marshal(results)
+		if err != nil {
+			log.Printf("marshal Religious Census city membership: %v", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(response))
+		if _, err := w.Write(response); err != nil {
+			log.Printf("write Religious Census city membership response: %v", err)
+		}
 	}
 }
 
@@ -204,33 +211,50 @@ func (s *Server) RelCensusLocationsHandler() http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		results := make([]LocationInfo, 0)
-		var row LocationInfo
 
-		rows, err := s.DB.Query(context.TODO(), query)
+		rows, err := s.DB.Query(r.Context(), query)
 		if err != nil {
-			log.Println(err)
+			log.Printf("query Religious Census locations: %v", err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
 		defer rows.Close()
 
 		for rows.Next() {
-			err := rows.Scan(&row.PlaceID, &row.City, &row.County, &row.State, &row.CountyAHCB, &row.MapName, &row.Lat, &row.Lon)
-			if err != nil {
-				log.Println(err)
+			var row LocationInfo
+			if err := rows.Scan(
+				&row.PlaceID,
+				&row.City,
+				&row.County,
+				&row.State,
+				&row.CountyAHCB,
+				&row.MapName,
+				&row.Lat,
+				&row.Lon,
+			); err != nil {
+				log.Printf("scan Religious Census location: %v", err)
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				return
 			}
 			results = append(results, row)
 		}
 
-		err = rows.Err()
-		if err != nil {
-			log.Println(err)
+		if err := rows.Err(); err != nil {
+			log.Printf("iterate Religious Census locations: %v", err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
 
-		response, _ := json.Marshal(results)
+		response, err := json.Marshal(results)
+		if err != nil {
+			log.Printf("marshal Religious Census locations: %v", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(response))
+		if _, err := w.Write(response); err != nil {
+			log.Printf("write Religious Census locations response: %v", err)
+		}
 	}
 }

--- a/request_context_test.go
+++ b/request_context_test.go
@@ -1,0 +1,205 @@
+package apiary
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type serviceRequestContextKey struct{}
+
+const serviceRequestContextMarker = "service-request-context"
+
+func TestServiceHandlersPropagateRequestCancellation(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		routeVars map[string]string
+		handler   func(*Server) http.HandlerFunc
+	}{
+		{
+			name: "Presbyterians",
+			path: "/presbyterians/",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.PresbyteriansHandler()
+			},
+		},
+		{
+			name: "Religious Census denomination families",
+			path: "/relcensus/denomination-families",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.RelCensusDenominationFamiliesHandler()
+			},
+		},
+		{
+			name: "Religious Census denominations",
+			path: "/relcensus/denominations?family_relec=Baptist",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.RelCensusDenominationsHandler()
+			},
+		},
+		{
+			name: "Religious Census city membership by denomination",
+			path: "/relcensus/city-membership?year=1926&denomination=Church+of+God+in+Christ",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.RelCensusCityMembershipHandler()
+			},
+		},
+		{
+			name: "Religious Census city membership by family",
+			path: "/relcensus/city-membership?year=1926&denominationFamily=Pentecostal",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.RelCensusCityMembershipHandler()
+			},
+		},
+		{
+			name: "Religious Census city membership aggregate",
+			path: "/relcensus/city-membership?year=1926",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.RelCensusCityMembershipHandler()
+			},
+		},
+		{
+			name: "Religious Census locations",
+			path: "/relcensus/cities",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.RelCensusLocationsHandler()
+			},
+		},
+		{
+			name: "Natural Earth globe",
+			path: "/ne/globe",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.NaturalEarthHandler()
+			},
+		},
+		{
+			name: "Natural Earth filtered globe",
+			path: "/ne/globe?location=Europe&location=Asia",
+			handler: func(server *Server) http.HandlerFunc {
+				return server.NaturalEarthHandler()
+			},
+		},
+		{
+			name:      "populated-place counties in state",
+			path:      "/pop-places/state/nc/county/",
+			routeVars: map[string]string{"state": "nc"},
+			handler: func(server *Server) http.HandlerFunc {
+				return server.CountiesInState()
+			},
+		},
+		{
+			name:      "populated places in county",
+			path:      "/pop-places/county/mas_middlesex/place/",
+			routeVars: map[string]string{"county": "mas_middlesex"},
+			handler: func(server *Server) http.HandlerFunc {
+				return server.PlacesInCounty()
+			},
+		},
+		{
+			name:      "populated-place details",
+			path:      "/pop-places/place/611119/",
+			routeVars: map[string]string{"place": "611119"},
+			handler: func(server *Server) http.HandlerFunc {
+				return server.Place()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			observedContext := make(chan context.Context, 1)
+			config, err := pgxpool.ParseConfig(
+				"postgres://apiary:apiary@127.0.0.1:1/apiary",
+			)
+			if err != nil {
+				t.Fatalf("parse database config: %v", err)
+			}
+			config.BeforeConnect = func(ctx context.Context, _ *pgx.ConnConfig) error {
+				observedContext <- ctx
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(500 * time.Millisecond):
+					return errors.New("database context was not canceled")
+				}
+			}
+
+			pool, err := pgxpool.NewWithConfig(context.Background(), config)
+			if err != nil {
+				t.Fatalf("create database pool: %v", err)
+			}
+			t.Cleanup(pool.Close)
+
+			requestContext := context.WithValue(
+				context.Background(),
+				serviceRequestContextKey{},
+				serviceRequestContextMarker,
+			)
+			requestContext, cancel := context.WithCancel(requestContext)
+			t.Cleanup(cancel)
+
+			request := httptest.NewRequest(http.MethodGet, tt.path, nil).
+				WithContext(requestContext)
+			request = mux.SetURLVars(request, tt.routeVars)
+			response := httptest.NewRecorder()
+			handlerDone := make(chan any, 1)
+
+			go func() {
+				var panicValue any
+				defer func() {
+					panicValue = recover()
+					handlerDone <- panicValue
+				}()
+				tt.handler(&Server{DB: pool}).ServeHTTP(response, request)
+			}()
+
+			select {
+			case databaseContext := <-observedContext:
+				if marker := databaseContext.Value(serviceRequestContextKey{}); marker != serviceRequestContextMarker {
+					t.Errorf(
+						"database context marker = %v, want %q",
+						marker,
+						serviceRequestContextMarker,
+					)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("handler did not start a database query")
+			}
+
+			cancel()
+
+			select {
+			case panicValue := <-handlerDone:
+				if panicValue != nil {
+					t.Fatalf("handler panicked after cancellation: %v", panicValue)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("handler did not stop after request cancellation")
+			}
+
+			if response.Code != http.StatusInternalServerError {
+				t.Fatalf(
+					"status = %d, want %d",
+					response.Code,
+					http.StatusInternalServerError,
+				)
+			}
+			if body := strings.TrimSpace(response.Body.String()); body != http.StatusText(http.StatusInternalServerError) {
+				t.Fatalf(
+					"body = %q, want %q",
+					body,
+					http.StatusText(http.StatusInternalServerError),
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed

- pass `r.Context()` into all 12 remaining request-scoped database calls
- cover Presbyterians, Religious Census, Natural Earth, and Populated Places in
  one sweep
- exercise all three Religious Census city-membership query branches
- return immediately on query, scan, row-iteration, and JSON-marshal failures
  instead of continuing into a panic or appending a success payload to an error
- keep scanned row values local to each iteration
- recognize `pgx.ErrNoRows` correctly so a missing populated place returns the
  handler's intended 404 response
- add table-driven cancellation coverage for every changed call site
- add live integration coverage for Religious Census locations and a missing
  populated place

## Why

These handlers used `context.TODO()` or `context.Background()`, detaching
database work from the lifetime of the HTTP request. Several query-error paths
also logged the error and continued, which could close an invalid row set or
emit JSON after an `Internal Server Error` response.

Using `r.Context()` lets PostgreSQL work stop when the client disconnects or the
server cancels the request. Returning immediately on failures prevents panics
and mixed error/success bodies.

This completes the request-context audit: the only remaining
`context.Background()` calls are intentional process-lifecycle roots in
`cmd/apiary/main.go` and `internal/lifecycle`.

Successful endpoint routes and JSON response shapes are unchanged. A nonexistent
populated-place ID now correctly returns the already-intended 404 rather than a
500 followed by an empty success object.

## Validation

- `go test -race . -run '^TestServiceHandlersPropagateRequestCancellation$' -count=1 -v`
- affected-family live integration tests
- `go test -race . -count=1`
- `go test ./cmd/apiary -count=1`
- `go build ./...`
- `go vet ./...`
- `go mod tidy -diff`
- `staticcheck ./...`
- `govulncheck ./...`
- `git diff --check`

Refs #100
