### PR TITLE
Harden response error handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,12 @@ jobs:
       - name: Vet
         run: go vet ./...
 
+      - name: Install gosec
+        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.28.0
+
+      - name: Security lint
+        run: gosec -exclude-dir=.claude ./...
+
       # Hermetic unit tests (root package) with the race detector. CGO is
       # available on ubuntu runners, which -race requires.
       - name: Unit tests (race)

--- a/apb-verse-quotations.go
+++ b/apb-verse-quotations.go
@@ -58,8 +58,8 @@ func (s *Server) APBVerseQuotationsHandler() http.HandlerFunc {
 		}
 
 		if len(results) == 0 {
-			w.WriteHeader(http.StatusNotFound)
-			w.Write([]byte("404 Not found."))
+			http.Error(w, "404 Not found.", http.StatusNotFound)
+			return
 		}
 
 		response, _ := json.Marshal(results)

--- a/apb-verse-trend.go
+++ b/apb-verse-trend.go
@@ -54,8 +54,7 @@ func (s *Server) APBVerseTrendHandler() http.HandlerFunc {
 		if len(queryRef) == 1 {
 			ref = queryRef[0]
 		} else {
-			w.WriteHeader(http.StatusBadRequest)
-			w.Write([]byte("400 Bad request. Please provide exactly one reference."))
+			http.Error(w, "400 Bad request. Please provide exactly one reference.", http.StatusBadRequest)
 			return
 		}
 
@@ -65,8 +64,7 @@ func (s *Server) APBVerseTrendHandler() http.HandlerFunc {
 		if len(corpusRef) > 0 {
 			corpus = corpusRef[0]
 			if !(corpus == "ncnp" || corpus == "chronam") {
-				w.WriteHeader(http.StatusBadRequest)
-				w.Write([]byte("400 Bad request. Corpus must be 'ncnp' or 'chronam'."))
+				http.Error(w, "400 Bad request. Corpus must be 'ncnp' or 'chronam'.", http.StatusBadRequest)
 				return
 			}
 		}

--- a/apb-verse.go
+++ b/apb-verse.go
@@ -1,11 +1,13 @@
 package apiary
 
 import (
-	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
+
+	"github.com/jackc/pgx/v5"
 )
 
 // Verse describes the reference and text of a single Bible verse
@@ -45,9 +47,8 @@ func (s *Server) APBVerseHandler() http.HandlerFunc {
 		var result Verse
 
 		err := s.DB.QueryRow(r.Context(), verseQuery, refs[0]).Scan(&result.Reference, &result.Text)
-		if err == sql.ErrNoRows {
-			w.WriteHeader(http.StatusNotFound)
-			w.Write([]byte("404 Not found."))
+		if errors.Is(err, pgx.ErrNoRows) {
+			http.Error(w, "404 Not found.", http.StatusNotFound)
 			return
 		} else if err != nil {
 			log.Println(err)

--- a/bom-bills.go
+++ b/bom-bills.go
@@ -203,7 +203,9 @@ func (s *Server) BillsHandler() http.HandlerFunc {
 			log.Printf("Error marshaling JSON: %v", err)
 			return
 		}
-		w.Write(response)
+		if _, err := w.Write(response); err != nil {
+			log.Printf("Error writing bills response: %v", err)
+		}
 	}
 }
 
@@ -796,8 +798,8 @@ func (s *Server) StatisticsHandler() http.HandlerFunc {
 		case "parish-yearly":
 			qb, buildErr := buildParishYearlyStatsQuery(parishName)
 			if buildErr != nil {
-				http.Error(w, "Error building query", http.StatusInternalServerError)
 				log.Printf("Error building parish-yearly query: %v", buildErr)
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 				return
 			}
 			rows, err = s.DB.Query(r.Context(), qb.Query, qb.Params...)
@@ -807,10 +809,7 @@ func (s *Server) StatisticsHandler() http.HandlerFunc {
 		}
 		if err != nil {
 			log.Printf("Database error executing query: %v", err)
-			if statType == "parish-yearly" {
-				log.Printf("Parish name: %s", parishName)
-			}
-			http.Error(w, fmt.Sprintf("Database error: %v", err), http.StatusInternalServerError)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
 		defer rows.Close()
@@ -823,7 +822,7 @@ func (s *Server) StatisticsHandler() http.HandlerFunc {
 				err := rows.Scan(&summary.Year, &summary.WeekNumber, &summary.RowsCount)
 				if err != nil {
 					log.Printf("Error scanning weekly summary: %v", err)
-					http.Error(w, fmt.Sprintf("Error processing results: %v", err), http.StatusInternalServerError)
+					http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 					return
 				}
 				stats = append(stats, summary)
@@ -832,7 +831,7 @@ func (s *Server) StatisticsHandler() http.HandlerFunc {
 			// Check for errors from iterating over rows
 			if err = rows.Err(); err != nil {
 				log.Printf("Error iterating over rows: %v", err)
-				http.Error(w, fmt.Sprintf("Error processing results: %v", err), http.StatusInternalServerError)
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 				return
 			}
 
@@ -849,7 +848,7 @@ func (s *Server) StatisticsHandler() http.HandlerFunc {
 					&summary.RowsCount, &summary.TotalCount)
 				if err != nil {
 					log.Printf("Error scanning yearly summary: %v", err)
-					http.Error(w, fmt.Sprintf("Error processing results: %v", err), http.StatusInternalServerError)
+					http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 					return
 				}
 				stats = append(stats, summary)
@@ -858,7 +857,7 @@ func (s *Server) StatisticsHandler() http.HandlerFunc {
 			// Check for errors from iterating over rows
 			if err = rows.Err(); err != nil {
 				log.Printf("Error iterating over rows: %v", err)
-				http.Error(w, fmt.Sprintf("Error processing results: %v", err), http.StatusInternalServerError)
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 				return
 			}
 
@@ -879,7 +878,7 @@ func (s *Server) StatisticsHandler() http.HandlerFunc {
 				)
 				if err != nil {
 					log.Printf("Error scanning parish-yearly summary: %v", err)
-					http.Error(w, fmt.Sprintf("Error processing results: %v", err), http.StatusInternalServerError)
+					http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 					return
 				}
 				stats = append(stats, summary)
@@ -888,7 +887,7 @@ func (s *Server) StatisticsHandler() http.HandlerFunc {
 			// Check for errors from iterating over rows
 			if err = rows.Err(); err != nil {
 				log.Printf("Error iterating over rows: %v", err)
-				http.Error(w, fmt.Sprintf("Error processing results: %v", err), http.StatusInternalServerError)
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 				return
 			}
 

--- a/bom-causes.go
+++ b/bom-causes.go
@@ -109,7 +109,6 @@ func (s *Server) DeathCausesHandler() http.HandlerFunc {
 		if billType != "" {
 			if !IsValidBillType(billType) {
 				http.Error(w, "Invalid bill type", http.StatusBadRequest)
-				log.Printf("Invalid bill type: %s", billType)
 				return
 			}
 		}
@@ -260,7 +259,6 @@ func (s *Server) ListCausesHandler() http.HandlerFunc {
 		if billType != "" {
 			if !IsValidBillType(billType) {
 				http.Error(w, "Invalid bill type", http.StatusBadRequest)
-				log.Printf("Invalid bill type: %s", billType)
 				return
 			}
 		}

--- a/bom-christenings.go
+++ b/bom-christenings.go
@@ -222,7 +222,6 @@ func (s *Server) ListChristeningsHandler() http.HandlerFunc {
 		if billType != "" {
 			if !IsValidBillType(billType) {
 				http.Error(w, "Invalid bill type", http.StatusBadRequest)
-				log.Printf("Invalid bill type: %s", billType)
 				return
 			}
 		}

--- a/bom_context_test.go
+++ b/bom_context_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -163,6 +164,15 @@ func TestBOMHandlersPropagateRequestCancellation(t *testing.T) {
 
 			if response.Code != http.StatusInternalServerError {
 				t.Fatalf("status = %d, want %d", response.Code, http.StatusInternalServerError)
+			}
+			if tt.name == "statistics" {
+				if body := strings.TrimSpace(response.Body.String()); body != http.StatusText(http.StatusInternalServerError) {
+					t.Fatalf(
+						"body = %q, want %q",
+						body,
+						http.StatusText(http.StatusInternalServerError),
+					)
+				}
 			}
 		})
 	}

--- a/cmd/apiary/apb_test.go
+++ b/cmd/apiary/apb_test.go
@@ -84,6 +84,12 @@ func TestAPBVerse(t *testing.T) {
 
 }
 
+func TestAPBVerseNotFound(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/apb/verse?ref=Not+A+Bible+Verse", nil)
+	response := executeRequest(req)
+	checkResponseCode(t, http.StatusNotFound, response.Code)
+}
+
 func TestAPBVerseTrend(t *testing.T) {
 	// Check that we get the right response
 	req, _ := http.NewRequest("GET", "/apb/verse-trend?ref=Genesis+1:1&corpus=chronam", nil)
@@ -109,6 +115,18 @@ func TestAPBVerseTrend(t *testing.T) {
 		t.Error("Not enough data points returned.")
 	}
 
+}
+
+func TestAPBVerseTrendRejectsMissingReference(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/apb/verse-trend", nil)
+	response := executeRequest(req)
+	checkResponseCode(t, http.StatusBadRequest, response.Code)
+}
+
+func TestAPBVerseTrendRejectsInvalidCorpus(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/apb/verse-trend?ref=Genesis+1:1&corpus=invalid", nil)
+	response := executeRequest(req)
+	checkResponseCode(t, http.StatusBadRequest, response.Code)
 }
 
 func TestAPBBibleTrend(t *testing.T) {
@@ -155,6 +173,12 @@ func TestAPBVerseQuotations(t *testing.T) {
 		t.Error("Not enough verses returned.")
 	}
 
+}
+
+func TestAPBVerseQuotationsNotFound(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/apb/verse-quotations?ref=Not+A+Bible+Verse", nil)
+	response := executeRequest(req)
+	checkResponseCode(t, http.StatusNotFound, response.Code)
 }
 
 func TestBiblicalIndex(t *testing.T) {

--- a/middleware.go
+++ b/middleware.go
@@ -58,8 +58,7 @@ func (w *noStoreOnError) WriteHeader(status int) {
 // NotFoundHandler returns 404 errors
 func (s *Server) NotFoundHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-		w.Write([]byte("404 Not found."))
+		http.Error(w, "404 Not found.", http.StatusNotFound)
 	})
 
 }


### PR DESCRIPTION
## What changed

- resolve all four `G706` log-injection findings by no longer logging raw,
  rejected BOM query parameters
- resolve all six `G104` ignored-write findings by using `http.Error` for error
  responses and checking the remaining JSON response write
- recognize `pgx.ErrNoRows` correctly in the APB verse handler
- stop APB quotation handling immediately after a not-found response
- keep BOM statistics database and row-processing details in server logs while
  returning a generic 500 response to clients
- add live regression coverage for APB not-found and bad-request paths
- assert that BOM statistics query failures return only the generic 500 body
- add a pinned `gosec v2.28.0` security-lint gate to the existing CI test job

## Why

The post-context-migration security baseline contained 10 low-severity findings:
four possible log-injection paths and six ignored response-write errors. Raw
user input could introduce control characters into logs, and ignored writes
made response failures invisible.

The audit also exposed two related correctness problems: APB verse lookups were
checking the `database/sql` no-row sentinel even though the service uses pgx,
and empty quotation results wrote a 404 before continuing into a JSON response.

The BOM statistics handler returned raw database and row-scan errors to clients.
Those details now remain in server logs while clients receive a generic
`Internal Server Error`.

## Validation

- focused BOM cancellation/error-response race tests
- focused APB and 404 live integration tests
- `go test -race . -count=1`
- `go test ./cmd/apiary -count=1`
- `go build ./...`
- `go vet ./...`
- `go mod tidy -diff`
- `staticcheck ./...`
- `govulncheck ./...`
- `gosec -exclude-dir=.claude ./...` — 0 findings
- `actionlint -color`
- `git diff --check`

Refs #100
