### PR TITLE
Harden database handler error paths

### DIFF
--- a/apb-bible-similarity.go
+++ b/apb-bible-similarity.go
@@ -1,9 +1,6 @@
 package apiary
 
 import (
-	"encoding/json"
-	"fmt"
-	"log"
 	"net/http"
 )
 
@@ -49,28 +46,24 @@ func (s *Server) APBBibleSimilarityHandler() http.HandlerFunc {
 
 		rows, err := s.DB.Query(r.Context(), query)
 		if err != nil {
-			log.Println(err)
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			internalServerError(w, "error querying Bible similarities", err)
 			return
 		}
 		defer rows.Close()
 
 		for rows.Next() {
-			err := rows.Scan(&edge.A, &edge.B, &edge.N)
-			if err != nil {
-				log.Println(err)
+			if err := rows.Scan(&edge.A, &edge.B, &edge.N); err != nil {
+				internalServerError(w, "error scanning Bible similarity", err)
+				return
 			}
 			result = append(result, edge)
 		}
-		err = rows.Err()
-		if err != nil {
-			log.Println(err)
+		if err := rows.Err(); err != nil {
+			internalServerError(w, "error iterating Bible similarities", err)
+			return
 		}
 
-		response, _ := json.Marshal(result)
-
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(response))
+		writeJSONResponse(w, result)
 	}
 
 }

--- a/apb-bible-trend.go
+++ b/apb-bible-trend.go
@@ -1,9 +1,6 @@
 package apiary
 
 import (
-	"encoding/json"
-	"fmt"
-	"log"
 	"net/http"
 )
 
@@ -42,29 +39,24 @@ func (s *Server) APBBibleTrendHandler() http.HandlerFunc {
 
 		rows, err := s.DB.Query(r.Context(), query, corpus, minYear, maxYear)
 		if err != nil {
-			log.Println(err)
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			internalServerError(w, "error querying Bible trend", err)
 			return
 		}
 		defer rows.Close()
 		for rows.Next() {
-			err := rows.Scan(&row.Year, &row.N, &row.QuotationRateSmooth)
-			if err != nil {
-				log.Println(err)
+			if err := rows.Scan(&row.Year, &row.N, &row.QuotationRateSmooth); err != nil {
+				internalServerError(w, "error scanning Bible trend", err)
+				return
 			}
 			results = append(results, row)
 		}
-		err = rows.Err()
-		if err != nil {
-			log.Println(err)
+		if err := rows.Err(); err != nil {
+			internalServerError(w, "error iterating Bible trend", err)
+			return
 		}
 
 		wrapper := VerseTrendResponse{Reference: "bible", Corpus: corpus, Trend: results}
-
-		response, _ := json.Marshal(wrapper)
-
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(response))
+		writeJSONResponse(w, wrapper)
 	}
 
 }

--- a/apb-bible.go
+++ b/apb-bible.go
@@ -1,9 +1,6 @@
 package apiary
 
 import (
-	"encoding/json"
-	"fmt"
-	"log"
 	"net/http"
 )
 
@@ -31,28 +28,24 @@ func (s *Server) APBBibleBooksHandler() http.HandlerFunc {
 
 		rows, err := s.DB.Query(r.Context(), query)
 		if err != nil {
-			log.Println(err)
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			internalServerError(w, "error querying Bible books", err)
 			return
 		}
 		defer rows.Close()
 
 		for rows.Next() {
-			err := rows.Scan(&book.Book, &book.Part, &book.Order)
-			if err != nil {
-				log.Println(err)
+			if err := rows.Scan(&book.Book, &book.Part, &book.Order); err != nil {
+				internalServerError(w, "error scanning Bible book", err)
+				return
 			}
 			result = append(result, book)
 		}
-		err = rows.Err()
-		if err != nil {
-			log.Println(err)
+		if err := rows.Err(); err != nil {
+			internalServerError(w, "error iterating Bible books", err)
+			return
 		}
 
-		response, _ := json.Marshal(result)
-
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(response))
+		writeJSONResponse(w, result)
 	}
 
 }

--- a/apb-index.go
+++ b/apb-index.go
@@ -1,9 +1,6 @@
 package apiary
 
 import (
-	"encoding/json"
-	"fmt"
-	"log"
 	"net/http"
 )
 
@@ -47,27 +44,23 @@ func (s *Server) APBIndexFeaturedHandler() http.HandlerFunc {
 
 		rows, err := s.DB.Query(r.Context(), query)
 		if err != nil {
-			log.Println(err)
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			internalServerError(w, "error querying featured verse index", err)
 			return
 		}
 		defer rows.Close()
 		for rows.Next() {
-			err := rows.Scan(&row.Reference, &row.Text, &row.Count)
-			if err != nil {
-				log.Println(err)
+			if err := rows.Scan(&row.Reference, &row.Text, &row.Count); err != nil {
+				internalServerError(w, "error scanning featured verse index", err)
+				return
 			}
 			results = append(results, row)
 		}
-		err = rows.Err()
-		if err != nil {
-			log.Println(err)
+		if err := rows.Err(); err != nil {
+			internalServerError(w, "error iterating featured verse index", err)
+			return
 		}
 
-		response, _ := json.Marshal(results)
-
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(response))
+		writeJSONResponse(w, results)
 	}
 
 }
@@ -90,27 +83,23 @@ func (s *Server) APBIndexBiblicalOrderHandler() http.HandlerFunc {
 
 		rows, err := s.DB.Query(r.Context(), query)
 		if err != nil {
-			log.Println(err)
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			internalServerError(w, "error querying biblical verse index", err)
 			return
 		}
 		defer rows.Close()
 		for rows.Next() {
-			err := rows.Scan(&row.Reference, &row.Text, &row.Count)
-			if err != nil {
-				log.Println(err)
+			if err := rows.Scan(&row.Reference, &row.Text, &row.Count); err != nil {
+				internalServerError(w, "error scanning biblical verse index", err)
+				return
 			}
 			results = append(results, row)
 		}
-		err = rows.Err()
-		if err != nil {
-			log.Println(err)
+		if err := rows.Err(); err != nil {
+			internalServerError(w, "error iterating biblical verse index", err)
+			return
 		}
 
-		response, _ := json.Marshal(results)
-
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(response))
+		writeJSONResponse(w, results)
 	}
 
 }
@@ -133,27 +122,23 @@ func (s *Server) APBIndexTopHandler() http.HandlerFunc {
 
 		rows, err := s.DB.Query(r.Context(), query)
 		if err != nil {
-			log.Println(err)
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			internalServerError(w, "error querying top verse index", err)
 			return
 		}
 		defer rows.Close()
 		for rows.Next() {
-			err := rows.Scan(&row.Reference, &row.Text, &row.Count)
-			if err != nil {
-				log.Println(err)
+			if err := rows.Scan(&row.Reference, &row.Text, &row.Count); err != nil {
+				internalServerError(w, "error scanning top verse index", err)
+				return
 			}
 			results = append(results, row)
 		}
-		err = rows.Err()
-		if err != nil {
-			log.Println(err)
+		if err := rows.Err(); err != nil {
+			internalServerError(w, "error iterating top verse index", err)
+			return
 		}
 
-		response, _ := json.Marshal(results)
-
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(response))
+		writeJSONResponse(w, results)
 	}
 
 }
@@ -177,27 +162,23 @@ func (s *Server) APBIndexChronologicalHandler() http.HandlerFunc {
 
 		rows, err := s.DB.Query(r.Context(), query)
 		if err != nil {
-			log.Println(err)
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			internalServerError(w, "error querying chronological verse index", err)
 			return
 		}
 		defer rows.Close()
 		for rows.Next() {
-			err := rows.Scan(&row.Reference, &row.Text, &row.Count, &row.Peak)
-			if err != nil {
-				log.Println(err)
+			if err := rows.Scan(&row.Reference, &row.Text, &row.Count, &row.Peak); err != nil {
+				internalServerError(w, "error scanning chronological verse index", err)
+				return
 			}
 			results = append(results, row)
 		}
-		err = rows.Err()
-		if err != nil {
-			log.Println(err)
+		if err := rows.Err(); err != nil {
+			internalServerError(w, "error iterating chronological verse index", err)
+			return
 		}
 
-		response, _ := json.Marshal(results)
-
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(response))
+		writeJSONResponse(w, results)
 	}
 
 }
@@ -220,27 +201,23 @@ func (s *Server) APBIndexAllHandler() http.HandlerFunc {
 
 		rows, err := s.DB.Query(r.Context(), query)
 		if err != nil {
-			log.Println(err)
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			internalServerError(w, "error querying complete verse index", err)
 			return
 		}
 		defer rows.Close()
 		for rows.Next() {
-			err := rows.Scan(&row.Reference, &row.Text)
-			if err != nil {
-				log.Println(err)
+			if err := rows.Scan(&row.Reference, &row.Text); err != nil {
+				internalServerError(w, "error scanning complete verse index", err)
+				return
 			}
 			results = append(results, row)
 		}
-		err = rows.Err()
-		if err != nil {
-			log.Println(err)
+		if err := rows.Err(); err != nil {
+			internalServerError(w, "error iterating complete verse index", err)
+			return
 		}
 
-		response, _ := json.Marshal(results)
-
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(response))
+		writeJSONResponse(w, results)
 	}
 
 }

--- a/apb-verse-quotations.go
+++ b/apb-verse-quotations.go
@@ -1,9 +1,6 @@
 package apiary
 
 import (
-	"encoding/json"
-	"fmt"
-	"log"
 	"net/http"
 )
 
@@ -40,21 +37,20 @@ func (s *Server) APBVerseQuotationsHandler() http.HandlerFunc {
 
 		rows, err := s.DB.Query(r.Context(), query, refs[0])
 		if err != nil {
-			log.Println(err)
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			internalServerError(w, "error querying verse quotations", err)
 			return
 		}
 		defer rows.Close()
 		for rows.Next() {
-			err := rows.Scan(&row.Reference, &row.DocID, &row.Date, &row.Probability, &row.Title, &row.State)
-			if err != nil {
-				log.Println(err)
+			if err := rows.Scan(&row.Reference, &row.DocID, &row.Date, &row.Probability, &row.Title, &row.State); err != nil {
+				internalServerError(w, "error scanning verse quotation", err)
+				return
 			}
 			results = append(results, row)
 		}
-		err = rows.Err()
-		if err != nil {
-			log.Println(err)
+		if err := rows.Err(); err != nil {
+			internalServerError(w, "error iterating verse quotations", err)
+			return
 		}
 
 		if len(results) == 0 {
@@ -62,10 +58,7 @@ func (s *Server) APBVerseQuotationsHandler() http.HandlerFunc {
 			return
 		}
 
-		response, _ := json.Marshal(results)
-
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(response))
+		writeJSONResponse(w, results)
 	}
 
 }

--- a/apb-verse-trend.go
+++ b/apb-verse-trend.go
@@ -1,9 +1,6 @@
 package apiary
 
 import (
-	"encoding/json"
-	"fmt"
-	"log"
 	"net/http"
 )
 
@@ -84,29 +81,24 @@ func (s *Server) APBVerseTrendHandler() http.HandlerFunc {
 
 		rows, err := s.DB.Query(r.Context(), query, corpus, ref, minYear, maxYear)
 		if err != nil {
-			log.Println(err)
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			internalServerError(w, "error querying verse trend", err)
 			return
 		}
 		defer rows.Close()
 		for rows.Next() {
-			err := rows.Scan(&row.Year, &row.N, &row.QuotationRateSmooth)
-			if err != nil {
-				log.Println(err)
+			if err := rows.Scan(&row.Year, &row.N, &row.QuotationRateSmooth); err != nil {
+				internalServerError(w, "error scanning verse trend", err)
+				return
 			}
 			results = append(results, row)
 		}
-		err = rows.Err()
-		if err != nil {
-			log.Println(err)
+		if err := rows.Err(); err != nil {
+			internalServerError(w, "error iterating verse trend", err)
+			return
 		}
 
 		wrapper := VerseTrendResponse{Reference: ref, Corpus: corpus, Trend: results}
-
-		response, _ := json.Marshal(wrapper)
-
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(response))
+		writeJSONResponse(w, wrapper)
 	}
 
 }

--- a/apb-verse.go
+++ b/apb-verse.go
@@ -1,10 +1,7 @@
 package apiary
 
 import (
-	"encoding/json"
 	"errors"
-	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/jackc/pgx/v5"
@@ -51,38 +48,32 @@ func (s *Server) APBVerseHandler() http.HandlerFunc {
 			http.Error(w, "404 Not found.", http.StatusNotFound)
 			return
 		} else if err != nil {
-			log.Println(err)
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			internalServerError(w, "error querying verse", err)
 			return
 		}
 
 		related := make([]string, 0)
 		rows, err := s.DB.Query(r.Context(), relatedVerseQuery, refs[0])
 		if err != nil {
-			log.Println(err)
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			internalServerError(w, "error querying related verses", err)
 			return
 		}
 		defer rows.Close()
 		var rel string
 		for rows.Next() {
-			err := rows.Scan(&rel)
-			if err != nil {
-				log.Println(err)
+			if err := rows.Scan(&rel); err != nil {
+				internalServerError(w, "error scanning related verse", err)
+				return
 			}
 			related = append(related, rel)
 		}
-		err = rows.Err()
-		if err != nil {
-			log.Println(err)
+		if err := rows.Err(); err != nil {
+			internalServerError(w, "error iterating related verses", err)
+			return
 		}
 
 		result.Related = related
-
-		response, _ := json.Marshal(result)
-
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(response))
+		writeJSONResponse(w, result)
 	}
 
 }

--- a/bom-bills.go
+++ b/bom-bills.go
@@ -2,7 +2,6 @@ package apiary
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -108,8 +107,7 @@ func (s *Server) BillsHandler() http.HandlerFunc {
 		if len(apiParams.Parish) > 0 {
 			invalid, err := s.invalidParishIDs(r.Context(), apiParams.Parish)
 			if err != nil {
-				log.Printf("Error validating parish IDs: %v", err)
-				http.Error(w, "Database error", http.StatusInternalServerError)
+				internalServerError(w, "error validating parish IDs", err)
 				return
 			}
 			if len(invalid) > 0 {
@@ -121,18 +119,14 @@ func (s *Server) BillsHandler() http.HandlerFunc {
 		// Build query with parameters
 		qb, err := buildBillsQueryWithParams(apiParams)
 		if err != nil {
-			http.Error(w, "Error building query", http.StatusInternalServerError)
-			log.Printf("Error building query: %v", err)
+			internalServerError(w, "error building bills query", err)
 			return
 		}
 
 		// Execute query with parameters
 		rows, err := s.DB.Query(r.Context(), qb.Query, qb.Params...)
 		if err != nil {
-			http.Error(w, "Database error", http.StatusInternalServerError)
-			log.Printf("Error executing query: %v", err)
-			log.Printf("Query: %s", qb.Query)
-			log.Printf("Params: %v", qb.Params)
+			internalServerError(w, "error querying bills", err)
 			return
 		}
 		defer rows.Close()
@@ -168,8 +162,7 @@ func (s *Server) BillsHandler() http.HandlerFunc {
 				&parish.Notes,
 			)
 			if err != nil {
-				http.Error(w, "Error processing results", http.StatusInternalServerError)
-				log.Printf("Error scanning row: %v", err)
+				internalServerError(w, "error scanning bill", err)
 				return
 			}
 			result.Parish = &parish
@@ -177,8 +170,7 @@ func (s *Server) BillsHandler() http.HandlerFunc {
 		}
 
 		if err = rows.Err(); err != nil {
-			http.Error(w, "Error processing results", http.StatusInternalServerError)
-			log.Printf("Error iterating through rows: %v", err)
+			internalServerError(w, "error iterating bills", err)
 			return
 		}
 
@@ -196,16 +188,7 @@ func (s *Server) BillsHandler() http.HandlerFunc {
 			}
 		}
 
-		w.Header().Set("Content-Type", "application/json")
-		response, err := json.Marshal(paginatedResponse)
-		if err != nil {
-			http.Error(w, "Error encoding response", http.StatusInternalServerError)
-			log.Printf("Error marshaling JSON: %v", err)
-			return
-		}
-		if _, err := w.Write(response); err != nil {
-			log.Printf("Error writing bills response: %v", err)
-		}
+		writeJSONResponse(w, paginatedResponse)
 	}
 }
 
@@ -652,10 +635,12 @@ func (s *Server) TotalBillsHandler() http.HandlerFunc {
 			rows, err = s.DB.Query(r.Context(), queryChristenings)
 		case totalValues == "causes":
 			rows, err = s.DB.Query(r.Context(), queryCauses)
+		default:
+			http.Error(w, "Invalid type parameter. Must be 'weekly', 'general', 'christenings', or 'causes'", http.StatusBadRequest)
+			return
 		}
 		if err != nil {
-			log.Println(err)
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			internalServerError(w, "error querying bill totals", err)
 			return
 		}
 		defer rows.Close()
@@ -663,16 +648,17 @@ func (s *Server) TotalBillsHandler() http.HandlerFunc {
 		for rows.Next() {
 			err := rows.Scan(&row.TotalRecords)
 			if err != nil {
-				log.Println(err)
-				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				internalServerError(w, "error scanning bill total", err)
 				return
 			}
 			results = append(results, row)
 		}
+		if err := rows.Err(); err != nil {
+			internalServerError(w, "error iterating bill totals", err)
+			return
+		}
 
-		response, _ := json.Marshal(results)
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(response))
+		writeJSONResponse(w, results)
 	}
 }
 
@@ -798,8 +784,7 @@ func (s *Server) StatisticsHandler() http.HandlerFunc {
 		case "parish-yearly":
 			qb, buildErr := buildParishYearlyStatsQuery(parishName)
 			if buildErr != nil {
-				log.Printf("Error building parish-yearly query: %v", buildErr)
-				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				internalServerError(w, "error building parish-yearly statistics query", buildErr)
 				return
 			}
 			rows, err = s.DB.Query(r.Context(), qb.Query, qb.Params...)
@@ -808,8 +793,7 @@ func (s *Server) StatisticsHandler() http.HandlerFunc {
 			return
 		}
 		if err != nil {
-			log.Printf("Database error executing query: %v", err)
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			internalServerError(w, "error querying statistics", err)
 			return
 		}
 		defer rows.Close()
@@ -821,8 +805,7 @@ func (s *Server) StatisticsHandler() http.HandlerFunc {
 				var summary WeeklySummary
 				err := rows.Scan(&summary.Year, &summary.WeekNumber, &summary.RowsCount)
 				if err != nil {
-					log.Printf("Error scanning weekly summary: %v", err)
-					http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+					internalServerError(w, "error scanning weekly statistics", err)
 					return
 				}
 				stats = append(stats, summary)
@@ -830,15 +813,11 @@ func (s *Server) StatisticsHandler() http.HandlerFunc {
 
 			// Check for errors from iterating over rows
 			if err = rows.Err(); err != nil {
-				log.Printf("Error iterating over rows: %v", err)
-				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				internalServerError(w, "error iterating weekly statistics", err)
 				return
 			}
 
-			w.Header().Set("Content-Type", "application/json")
-			if err := json.NewEncoder(w).Encode(stats); err != nil {
-				log.Printf("Error encoding JSON response: %v", err)
-			}
+			writeJSONResponse(w, stats)
 
 		case "yearly":
 			stats := []YearlySummary{}
@@ -847,8 +826,7 @@ func (s *Server) StatisticsHandler() http.HandlerFunc {
 				err := rows.Scan(&summary.Year, &summary.WeeksCompleted,
 					&summary.RowsCount, &summary.TotalCount)
 				if err != nil {
-					log.Printf("Error scanning yearly summary: %v", err)
-					http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+					internalServerError(w, "error scanning yearly statistics", err)
 					return
 				}
 				stats = append(stats, summary)
@@ -856,15 +834,11 @@ func (s *Server) StatisticsHandler() http.HandlerFunc {
 
 			// Check for errors from iterating over rows
 			if err = rows.Err(); err != nil {
-				log.Printf("Error iterating over rows: %v", err)
-				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				internalServerError(w, "error iterating yearly statistics", err)
 				return
 			}
 
-			w.Header().Set("Content-Type", "application/json")
-			if err := json.NewEncoder(w).Encode(stats); err != nil {
-				log.Printf("Error encoding JSON response: %v", err)
-			}
+			writeJSONResponse(w, stats)
 
 		case "parish-yearly":
 			stats := []ParishYearlySummary{}
@@ -877,8 +851,7 @@ func (s *Server) StatisticsHandler() http.HandlerFunc {
 					&summary.TotalPlague,
 				)
 				if err != nil {
-					log.Printf("Error scanning parish-yearly summary: %v", err)
-					http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+					internalServerError(w, "error scanning parish-yearly statistics", err)
 					return
 				}
 				stats = append(stats, summary)
@@ -886,16 +859,12 @@ func (s *Server) StatisticsHandler() http.HandlerFunc {
 
 			// Check for errors from iterating over rows
 			if err = rows.Err(); err != nil {
-				log.Printf("Error iterating over rows: %v", err)
-				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				internalServerError(w, "error iterating parish-yearly statistics", err)
 				return
 			}
 
 			log.Printf("Returning %d parish-yearly summary records", len(stats))
-			w.Header().Set("Content-Type", "application/json")
-			if err := json.NewEncoder(w).Encode(stats); err != nil {
-				log.Printf("Error encoding JSON response: %v", err)
-			}
+			writeJSONResponse(w, stats)
 		}
 	}
 }

--- a/bom-bills_test.go
+++ b/bom-bills_test.go
@@ -1,10 +1,26 @@
 package apiary
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 )
+
+func TestTotalBillsHandlerRejectsInvalidType(t *testing.T) {
+	request := httptest.NewRequest(http.MethodGet, "/bom/totalbills?type=unknown", nil)
+	response := httptest.NewRecorder()
+
+	(&Server{}).TotalBillsHandler().ServeHTTP(response, request)
+
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusBadRequest)
+	}
+	if body := strings.TrimSpace(response.Body.String()); !strings.HasPrefix(body, "Invalid type parameter.") {
+		t.Fatalf("body = %q, want invalid type error", body)
+	}
+}
 
 func TestParseAPIParametersParish(t *testing.T) {
 	// Non-integer parish IDs are rejected by the parser.

--- a/bom-causes.go
+++ b/bom-causes.go
@@ -1,7 +1,6 @@
 package apiary
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -204,8 +203,7 @@ func (s *Server) DeathCausesHandler() http.HandlerFunc {
 
 		rows, err = s.DB.Query(r.Context(), query, params...)
 		if err != nil {
-			log.Printf("error querying death causes: %v", err)
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			internalServerError(w, "error querying death causes", err)
 			return
 		}
 
@@ -229,23 +227,17 @@ func (s *Server) DeathCausesHandler() http.HandlerFunc {
 				&row.TotalRecords,
 			)
 			if err != nil {
-				log.Printf("Error scanning row: %v", err)
-				log.Printf("Types: death=%T, name=%T, billType=%T, count=%T, definition=%T, definitionSource=%T, weekID=%T, weekNumber=%T, startDay=%T, startMonth=%T, endDay=%T, endMonth=%T, year=%T, splitYear=%T, totalRecords=%T",
-					row.Death, row.Name, row.BillType, row.Count, row.Definition, row.DefinitionSource, row.WeekID, row.WeekNumber, row.StartDay, row.StartMonth, row.EndDay, row.EndMonth, row.Year, row.SplitYear, row.TotalRecords)
-				continue
+				internalServerError(w, "error scanning death cause", err)
+				return
 			}
 			results = append(results, row)
 		}
-		err = rows.Err()
-		if err != nil {
-			log.Println(err)
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		if err := rows.Err(); err != nil {
+			internalServerError(w, "error iterating death causes", err)
 			return
 		}
 
-		response, _ := json.Marshal(results)
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(response))
+		writeJSONResponse(w, results)
 	}
 }
 
@@ -293,27 +285,22 @@ func (s *Server) ListCausesHandler() http.HandlerFunc {
 		}
 
 		if err != nil {
-			log.Println(err)
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			internalServerError(w, "error querying cause list", err)
 			return
 		}
 		defer rows.Close()
 		for rows.Next() {
-			err := rows.Scan(&row.Name, &row.BillType)
-			if err != nil {
-				log.Println(err)
+			if err := rows.Scan(&row.Name, &row.BillType); err != nil {
+				internalServerError(w, "error scanning cause list", err)
+				return
 			}
 			results = append(results, row)
 		}
-		err = rows.Err()
-		if err != nil {
-			log.Println(err)
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		if err := rows.Err(); err != nil {
+			internalServerError(w, "error iterating cause list", err)
 			return
 		}
 
-		response, _ := json.Marshal(results)
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(response))
+		writeJSONResponse(w, results)
 	}
 }

--- a/bom-christenings.go
+++ b/bom-christenings.go
@@ -1,9 +1,7 @@
 package apiary
 
 import (
-	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -177,8 +175,7 @@ func (s *Server) ChristeningsHandler() http.HandlerFunc {
 		}
 
 		if err != nil {
-			log.Println(err)
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			internalServerError(w, "error querying christenings", err)
 			return
 		}
 		defer rows.Close()
@@ -196,20 +193,17 @@ func (s *Server) ChristeningsHandler() http.HandlerFunc {
 				&row.TotalRecords,
 			)
 			if err != nil {
-				log.Println(err)
+				internalServerError(w, "error scanning christening", err)
+				return
 			}
 			results = append(results, row)
 		}
-		err = rows.Err()
-		if err != nil {
-			log.Println(err)
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		if err := rows.Err(); err != nil {
+			internalServerError(w, "error iterating christenings", err)
 			return
 		}
 
-		response, _ := json.Marshal(results)
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(response))
+		writeJSONResponse(w, results)
 	}
 }
 
@@ -256,27 +250,22 @@ func (s *Server) ListChristeningsHandler() http.HandlerFunc {
 		}
 
 		if err != nil {
-			log.Println(err)
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			internalServerError(w, "error querying christening list", err)
 			return
 		}
 		defer rows.Close()
 		for rows.Next() {
-			err := rows.Scan(&row.Name, &row.BillType)
-			if err != nil {
-				log.Println(err)
+			if err := rows.Scan(&row.Name, &row.BillType); err != nil {
+				internalServerError(w, "error scanning christening list", err)
+				return
 			}
 			results = append(results, row)
 		}
-		err = rows.Err()
-		if err != nil {
-			log.Println(err)
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		if err := rows.Err(); err != nil {
+			internalServerError(w, "error iterating christening list", err)
 			return
 		}
 
-		response, _ := json.Marshal(results)
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(response))
+		writeJSONResponse(w, results)
 	}
 }

--- a/bom-parishes.go
+++ b/bom-parishes.go
@@ -2,9 +2,6 @@ package apiary
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"log"
 	"net/http"
 )
 
@@ -76,27 +73,29 @@ func (s *Server) ParishesHandler() http.HandlerFunc {
 
 		rows, err := s.DB.Query(r.Context(), query)
 		if err != nil {
-			log.Println(err)
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			internalServerError(w, "error querying parishes", err)
 			return
 		}
 		defer rows.Close()
 		for rows.Next() {
-			err := rows.Scan(&row.ParishID, &row.Name, &row.CanonicalName, &row.BillSubunit, &row.FoundationYear, &row.Notes)
-			if err != nil {
-				log.Println(err)
+			if err := rows.Scan(
+				&row.ParishID,
+				&row.Name,
+				&row.CanonicalName,
+				&row.BillSubunit,
+				&row.FoundationYear,
+				&row.Notes,
+			); err != nil {
+				internalServerError(w, "error scanning parish", err)
+				return
 			}
 			results = append(results, row)
 		}
-		err = rows.Err()
-		if err != nil {
-			log.Println(err)
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		if err := rows.Err(); err != nil {
+			internalServerError(w, "error iterating parishes", err)
 			return
 		}
 
-		response, _ := json.Marshal(results)
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(response))
+		writeJSONResponse(w, results)
 	}
 }

--- a/bom_context_test.go
+++ b/bom_context_test.go
@@ -165,14 +165,12 @@ func TestBOMHandlersPropagateRequestCancellation(t *testing.T) {
 			if response.Code != http.StatusInternalServerError {
 				t.Fatalf("status = %d, want %d", response.Code, http.StatusInternalServerError)
 			}
-			if tt.name == "statistics" {
-				if body := strings.TrimSpace(response.Body.String()); body != http.StatusText(http.StatusInternalServerError) {
-					t.Fatalf(
-						"body = %q, want %q",
-						body,
-						http.StatusText(http.StatusInternalServerError),
-					)
-				}
+			if body := strings.TrimSpace(response.Body.String()); body != http.StatusText(http.StatusInternalServerError) {
+				t.Fatalf(
+					"body = %q, want %q",
+					body,
+					http.StatusText(http.StatusInternalServerError),
+				)
 			}
 		})
 	}

--- a/cache-test.go
+++ b/cache-test.go
@@ -1,8 +1,6 @@
 package apiary
 
 import (
-	"encoding/json"
-	"fmt"
 	"net/http"
 	"time"
 )
@@ -20,8 +18,6 @@ func (s *Server) CacheTest() http.HandlerFunc {
 			Startup: startup,
 			Handler: time.Now(), // This will be the time the handler was run
 		}
-		response, _ := json.Marshal(out)
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(response))
+		writeJSONResponse(w, out)
 	}
 }

--- a/endpoints.go
+++ b/endpoints.go
@@ -3,6 +3,7 @@ package apiary
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 )
@@ -397,9 +398,15 @@ func (s *Server) EndpointsHandler() http.HandlerFunc {
 			},
 		}
 
-		response, _ := json.MarshalIndent(endpoints, "", "  ")
+		response, err := json.MarshalIndent(endpoints, "", "  ")
+		if err != nil {
+			internalServerError(w, "error marshaling endpoint index", err)
+			return
+		}
 		resp := strings.Replace(string(response), "\\u0026", "&", -1)
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, resp)
+		if _, err := fmt.Fprint(w, resp); err != nil {
+			log.Printf("error writing endpoint index: %v", err)
+		}
 	}
 }

--- a/helpers.go
+++ b/helpers.go
@@ -3,11 +3,36 @@ package apiary
 import (
 	"database/sql"
 	"encoding/json"
+	"log"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
 	"time"
 )
+
+// internalServerError logs an internal error and returns a generic response to
+// the client so database and encoding details are never exposed.
+func internalServerError(w http.ResponseWriter, operation string, err error) {
+	log.Printf("%s: %v", operation, err)
+	http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+}
+
+// writeJSONResponse marshals a response before writing headers, allowing
+// encoding failures to return a generic 500 response. Write failures can only
+// be logged because the response may already be partially sent.
+func writeJSONResponse(w http.ResponseWriter, value any) {
+	response, err := json.Marshal(value)
+	if err != nil {
+		internalServerError(w, "error marshaling JSON response", err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if _, err := w.Write(response); err != nil {
+		log.Printf("error writing JSON response: %v", err)
+	}
+}
 
 // getEnv either returns the value of an environment variable or, if that
 // environment variables does not exist, returns the fallback value provided.

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -3,10 +3,57 @@ package apiary
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
+
+type failingJSONMarshaler struct{}
+
+func (failingJSONMarshaler) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("test encoding failure")
+}
+
+func TestWriteJSONResponse(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		response := httptest.NewRecorder()
+
+		writeJSONResponse(response, struct {
+			Status string `json:"status"`
+		}{Status: "ok"})
+
+		if response.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", response.Code, http.StatusOK)
+		}
+		if contentType := response.Header().Get("Content-Type"); contentType != "application/json" {
+			t.Fatalf("Content-Type = %q, want application/json", contentType)
+		}
+		if body := response.Body.String(); body != `{"status":"ok"}` {
+			t.Fatalf(`body = %q, want {"status":"ok"}`, body)
+		}
+	})
+
+	t.Run("encoding failure", func(t *testing.T) {
+		response := httptest.NewRecorder()
+
+		writeJSONResponse(response, failingJSONMarshaler{})
+
+		if response.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want %d", response.Code, http.StatusInternalServerError)
+		}
+		if body := strings.TrimSpace(response.Body.String()); body != http.StatusText(http.StatusInternalServerError) {
+			t.Fatalf(
+				"body = %q, want %q",
+				body,
+				http.StatusText(http.StatusInternalServerError),
+			)
+		}
+	})
+}
 
 func Test_dateInRange(t *testing.T) {
 	minDate, _ := time.Parse("2006-01-02", "1783-09-03")


### PR DESCRIPTION
## Summary

- stop APB and BOM handlers immediately on row-scan and iteration failures
- centralize generic internal-error and JSON response handling so implementation details stay in server logs
- validate unknown BOM total-count types instead of allowing a nil-row panic
- require generic 500 response bodies across every APB and BOM cancellation regression

## Verification

- `go test -race . -count=1`
- `go test ./cmd/apiary -count=1`
- `go build ./...`
- `go vet ./...`
- `go mod tidy -diff`
- `staticcheck ./...`
- `govulncheck ./...`
- `gosec -quiet -exclude-dir=.claude ./...`
- `actionlint -color`
- `git diff --check`

Refs #100