### PR TITLE
Clean up generated build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,13 @@
-cmd/apiary/apiary
 .env
-cmd/apiary/.env
-cmd/apiary/__debug_bin
-
 .env.fish
-.claude/
+cmd/apiary/.env
 
+# Go build and test outputs
+/apiary
+/cmd/apiary/apiary
+/cmd/apiary/__debug_bin
+/cmd/dataapi/dataapi
+*.test
+coverage.out
+
+.claude/

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
-.PHONY : serve
-serve : build
-	APIARY_INTERFACE=localhost ./cmd/apiary/apiary
+BINARY := cmd/apiary/apiary
 
 .PHONY : build
 build :
-	go build
-	cd cmd/apiary && go build
+	go build -o $(BINARY) ./cmd/apiary
+
+.PHONY : serve
+serve : build
+	APIARY_INTERFACE=localhost ./$(BINARY)
 
 .PHONY : install
 install :
-	go build
-	cd cmd/apiary && go install
+	go install ./cmd/apiary
 
 .PHONY : test
 test :

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ Building from source requires Go 1.25 or newer. The module selects Go 1.26.5
 as its preferred toolchain. There is a `Makefile` in the root of the repository
 that can be used for compiling and for running the service locally.
 
-- `make build` will build the binary.
-- `make install` will build the binary and install it under the name `apiary` to your `$GOPATH`.
+- `make build` will build the local binary at `cmd/apiary/apiary`.
+- `make install` will install the `apiary` binary to `$GOBIN`, or to
+  `$GOPATH/bin` when `$GOBIN` is not set.
 - `make serve` will serve the API locally.
 - `make docker-build` will create a Docker container for the API.
 - `make docker-serve` will create the container and run it locally via Docker.


### PR DESCRIPTION
## Summary

- remove the tracked 7.5 MB arm64 `cmd/dataapi/dataapi` executable
- ignore local Go build, debug, test, and coverage outputs
- make the local binary destination explicit in `make build`
- modernize the documented `make install` destination

## Impact

This removes a platform-specific generated artifact from source control without changing the application runtime. Local `make build`, `make serve`, and `make install` behavior remains supported.

## Verification

- `make build`
- isolated `GOBIN` `make install`
- `go test -race . -count=1`
- `go test ./internal/lifecycle -count=1`
- `go build ./...`
- `go vet ./...`
- `go mod tidy -diff`
- `staticcheck ./...`
- `govulncheck ./...`
- `gosec -quiet -exclude-dir=.claude ./...`
- `actionlint -color`
- generated-output ignore and tracked-artifact checks

Refs #100
