### PR TITLE
Make integration tests deterministic

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,12 @@ that can be used for compiling and for running the service locally.
 
 ## Testing
 
-You can run `make test` to run integration tests with the database. Or run `go test -v ./...` to get more verbose tests.
+The test suites have different runtime requirements:
+
+- `go test -race .` runs the deterministic root-package unit tests.
+- `go test ./cmd/apiary` runs integration tests against the PostgreSQL
+  database configured by `APIARY_DB`. These tests validate response contracts
+  and stable invariants rather than snapshotting mutable database records.
+- `go test ./db` runs the Gnomock connection test and requires a Docker daemon.
+- `make test` or `go test ./...` runs all suites and therefore requires both
+  PostgreSQL and Docker.

--- a/bom-bills_test.go
+++ b/bom-bills_test.go
@@ -1,6 +1,7 @@
 package apiary
 
 import (
+	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -48,5 +49,277 @@ func TestParseAPIParametersParish(t *testing.T) {
 	}
 	if !reflect.DeepEqual(params.Parish, []int{0, 99999}) {
 		t.Errorf("expected [0 99999], got %v", params.Parish)
+	}
+}
+
+func TestAPIParametersGetQueryOptions(t *testing.T) {
+	tests := []struct {
+		name   string
+		params APIParameters
+		want   QueryOptions
+	}{
+		{
+			name:   "direct limit and offset",
+			params: APIParameters{Limit: 50, Offset: 10},
+			want:   QueryOptions{Limit: 50, Offset: 10},
+		},
+		{
+			name:   "page overrides direct pagination",
+			params: APIParameters{Page: 3, Limit: 50, Offset: 10},
+			want:   QueryOptions{Limit: 25, Offset: 50},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.params.GetQueryOptions(); got != tt.want {
+				t.Fatalf("GetQueryOptions() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCursorRoundTrip(t *testing.T) {
+	cursor, err := generateCursor(1665, 12, "All Hallows")
+	if err != nil {
+		t.Fatalf("generateCursor: %v", err)
+	}
+
+	year, week, name, err := parseCursor(cursor)
+	if err != nil {
+		t.Fatalf("parseCursor: %v", err)
+	}
+	if year != 1665 || week != 12 || name != "All Hallows" {
+		t.Fatalf(
+			"parseCursor() = (%d, %d, %q), want (1665, 12, %q)",
+			year,
+			week,
+			name,
+			"All Hallows",
+		)
+	}
+}
+
+func TestParseCursorRejectsMalformedValues(t *testing.T) {
+	tests := []struct {
+		name   string
+		cursor string
+	}{
+		{name: "invalid base64", cursor: "%%%"},
+		{
+			name:   "wrong field count",
+			cursor: base64.URLEncoding.EncodeToString([]byte("1665|12")),
+		},
+		{
+			name:   "invalid year",
+			cursor: base64.URLEncoding.EncodeToString([]byte("year|12|Parish")),
+		},
+		{
+			name:   "invalid week",
+			cursor: base64.URLEncoding.EncodeToString([]byte("1665|week|Parish")),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, _, _, err := parseCursor(tt.cursor); err == nil {
+				t.Fatal("parseCursor returned nil error")
+			}
+		})
+	}
+}
+
+func TestGetEffectiveLimit(t *testing.T) {
+	tests := []struct {
+		name   string
+		params APIParameters
+		want   int
+	}{
+		{name: "default", params: APIParameters{}, want: 100},
+		{name: "direct", params: APIParameters{Limit: 25}, want: 25},
+		{name: "page", params: APIParameters{Page: 2, Limit: 25}, want: 100},
+		{name: "cursor", params: APIParameters{Cursor: "cursor", Limit: 25}, want: 100},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getEffectiveLimit(tt.params); got != tt.want {
+				t.Fatalf("getEffectiveLimit() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseAPIParameters(t *testing.T) {
+	cursor, err := generateCursor(1665, 12, "All Hallows")
+	if err != nil {
+		t.Fatalf("generate cursor: %v", err)
+	}
+
+	request := httptest.NewRequest(
+		http.MethodGet,
+		"/bom/bills?start-year=1664&end-year=1666&start-week=2&end-week=50"+
+			"&parish=1,2&bill-type=Weekly&count-type=Buried&missing=true"+
+			"&illegible=false&limit=25&offset=5&page=2&sort=canonical_name"+
+			"&cursor="+cursor,
+		nil,
+	)
+	params, err := parseAPIParameters(request)
+	if err != nil {
+		t.Fatalf("parseAPIParameters: %v", err)
+	}
+
+	if params.StartYear != 1664 || params.EndYear != 1666 {
+		t.Fatalf("year range = %d-%d, want 1664-1666", params.StartYear, params.EndYear)
+	}
+	if params.StartWeek != 2 || params.EndWeek != 50 {
+		t.Fatalf("week range = %d-%d, want 2-50", params.StartWeek, params.EndWeek)
+	}
+	if !reflect.DeepEqual(params.Parish, []int{1, 2}) {
+		t.Fatalf("parishes = %v, want [1 2]", params.Parish)
+	}
+	if params.BillType != "Weekly" || params.CountType != "Buried" {
+		t.Fatalf("types = (%q, %q), want (Weekly, Buried)", params.BillType, params.CountType)
+	}
+	if params.Missing == nil || !*params.Missing {
+		t.Fatal("missing parameter was not parsed as true")
+	}
+	if params.Illegible == nil || *params.Illegible {
+		t.Fatal("illegible parameter was not parsed as false")
+	}
+	if params.Limit != 25 || params.Offset != 5 || params.Page != 2 {
+		t.Fatalf(
+			"pagination = limit %d offset %d page %d, want 25, 5, 2",
+			params.Limit,
+			params.Offset,
+			params.Page,
+		)
+	}
+	if params.Sort != "canonical_name" {
+		t.Fatalf("sort = %q, want canonical_name", params.Sort)
+	}
+	if params.CursorYear != 1665 || params.CursorWeek != 12 || params.CursorName != "All Hallows" {
+		t.Fatalf(
+			"cursor = (%d, %d, %q), want (1665, 12, All Hallows)",
+			params.CursorYear,
+			params.CursorWeek,
+			params.CursorName,
+		)
+	}
+}
+
+func TestParseAPIParametersRejectsMalformedValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{name: "start year", query: "start-year=year"},
+		{name: "end year", query: "end-year=year"},
+		{name: "start week type", query: "start-week=week"},
+		{name: "start week range", query: "start-week=0"},
+		{name: "end week type", query: "end-week=week"},
+		{name: "end week range", query: "end-week=54"},
+		{name: "bill type", query: "bill-type=monthly"},
+		{name: "count type", query: "count-type=unknown"},
+		{name: "missing", query: "missing=sometimes"},
+		{name: "illegible", query: "illegible=sometimes"},
+		{name: "limit", query: "limit=many"},
+		{name: "offset", query: "offset=later"},
+		{name: "page", query: "page=next"},
+		{name: "cursor", query: "cursor=invalid!"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, "/bom/bills?"+tt.query, nil)
+			if _, err := parseAPIParameters(request); err == nil {
+				t.Fatal("parseAPIParameters returned nil error")
+			}
+		})
+	}
+}
+
+func TestBuildBillsQueryPaginationModes(t *testing.T) {
+	tests := []struct {
+		name          string
+		params        APIParameters
+		queryContains []string
+		wantParams    []interface{}
+	}{
+		{
+			name:          "default",
+			params:        APIParameters{},
+			queryContains: []string{"COUNT(*) OVER()", "LIMIT $1"},
+			wantParams:    []interface{}{100},
+		},
+		{
+			name:          "direct",
+			params:        APIParameters{Limit: 25, Offset: 10},
+			queryContains: []string{"LIMIT $1 OFFSET $2"},
+			wantParams:    []interface{}{25, 10},
+		},
+		{
+			name:          "page",
+			params:        APIParameters{Page: 2},
+			queryContains: []string{"LIMIT $1 OFFSET $2"},
+			wantParams:    []interface{}{100, 100},
+		},
+		{
+			name: "cursor",
+			params: APIParameters{
+				Cursor:     "cursor",
+				CursorYear: 1665,
+				CursorWeek: 12,
+				CursorName: "All Hallows",
+			},
+			queryContains: []string{
+				"0 AS totalrecords",
+				"(b.year, w.week_number, p.canonical_name) > ($1, $2, $3)",
+				"LIMIT $4",
+			},
+			wantParams: []interface{}{1665, 12, "All Hallows", 100},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query, err := buildBillsQueryWithParams(tt.params)
+			if err != nil {
+				t.Fatalf("buildBillsQueryWithParams: %v", err)
+			}
+			for _, fragment := range tt.queryContains {
+				if !strings.Contains(query.Query, fragment) {
+					t.Errorf("query does not contain %q", fragment)
+				}
+			}
+			if !reflect.DeepEqual(query.Params, tt.wantParams) {
+				t.Fatalf("params = %#v, want %#v", query.Params, tt.wantParams)
+			}
+		})
+	}
+}
+
+func TestBuildStatisticsQueries(t *testing.T) {
+	if query := buildWeeklyStatsQuery(); !strings.Contains(query, "year_week_range") {
+		t.Fatalf("weekly statistics query missing generated year/week range")
+	}
+
+	allParishes, err := buildParishYearlyStatsQuery("")
+	if err != nil {
+		t.Fatalf("build all-parish statistics query: %v", err)
+	}
+	if len(allParishes.Params) != 0 {
+		t.Fatalf("all-parish params = %#v, want none", allParishes.Params)
+	}
+
+	filtered, err := buildParishYearlyStatsQuery("All Hallows")
+	if err != nil {
+		t.Fatalf("build filtered parish statistics query: %v", err)
+	}
+	if !strings.Contains(filtered.Query, "LOWER(p.canonical_name) = LOWER($1)") {
+		t.Fatal("filtered parish query does not use a parameter placeholder")
+	}
+	if !reflect.DeepEqual(filtered.Params, []interface{}{"All Hallows"}) {
+		t.Fatalf("filtered parish params = %#v, want All Hallows", filtered.Params)
 	}
 }

--- a/cmd/apiary/ahcb_test.go
+++ b/cmd/apiary/ahcb_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"net/http"
 	"testing"
 )
@@ -11,25 +10,8 @@ func TestAHCBStates(t *testing.T) {
 	response := executeRequest(req)
 	checkResponseCode(t, http.StatusOK, response.Code)
 
-	// Get the data
-	type GeoJSONFeatureCollection struct {
-		Type     string        `json:"type"`
-		Features []interface{} `json:"features"`
-	}
-	var data GeoJSONFeatureCollection
-	err := json.Unmarshal(response.Body.Bytes(), &data)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if data.Type != "FeatureCollection" {
-		t.Error("Data is not a FeatureCollection.")
-	}
-
-	if len(data.Features) != 16 {
-		t.Error("Incorrect number of counties returned.")
-	}
-
+	data := decodeResponse[GeoJSONFeatureCollection](t, response)
+	requireNonEmptyFeatureCollection(t, data)
 }
 
 func TestAHCBCounties(t *testing.T) {
@@ -37,21 +19,8 @@ func TestAHCBCounties(t *testing.T) {
 	response := executeRequest(req)
 	checkResponseCode(t, http.StatusOK, response.Code)
 
-	// Get the data
-	var data GeoJSONFeatureCollection
-	err := json.Unmarshal(response.Body.Bytes(), &data)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if data.Type != "FeatureCollection" {
-		t.Error("Data is not a FeatureCollection.")
-	}
-
-	if len(data.Features) != 3113 {
-		t.Error("Incorrect number of features returned.")
-	}
-
+	data := decodeResponse[GeoJSONFeatureCollection](t, response)
+	requireNonEmptyFeatureCollection(t, data)
 }
 
 func TestAHCBCountiesByID(t *testing.T) {
@@ -60,20 +29,8 @@ func TestAHCBCountiesByID(t *testing.T) {
 	response := executeRequest(req)
 	checkResponseCode(t, http.StatusOK, response.Code)
 
-	// Get the data
-	var data GeoJSONFeatureCollection
-	err := json.Unmarshal(response.Body.Bytes(), &data)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if data.Type != "FeatureCollection" {
-		t.Error("Data is not a FeatureCollection.")
-	}
-
-	if len(data.Features) != 3 {
-		t.Error("Incorrect number of features returned.")
-	}
+	data := decodeResponse[GeoJSONFeatureCollection](t, response)
+	requireNonEmptyFeatureCollection(t, data)
 }
 
 func TestAHCBCountiesByStateTerrId(t *testing.T) {
@@ -82,20 +39,8 @@ func TestAHCBCountiesByStateTerrId(t *testing.T) {
 	response := executeRequest(req)
 	checkResponseCode(t, http.StatusOK, response.Code)
 
-	// Get the data
-	var data GeoJSONFeatureCollection
-	err := json.Unmarshal(response.Body.Bytes(), &data)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if data.Type != "FeatureCollection" {
-		t.Error("Data is not a FeatureCollection.")
-	}
-
-	if len(data.Features) != 295 {
-		t.Error("Incorrect number of features returned.")
-	}
+	data := decodeResponse[GeoJSONFeatureCollection](t, response)
+	requireNonEmptyFeatureCollection(t, data)
 }
 
 func TestAHCBCountiesByStateCode(t *testing.T) {
@@ -104,18 +49,6 @@ func TestAHCBCountiesByStateCode(t *testing.T) {
 	response := executeRequest(req)
 	checkResponseCode(t, http.StatusOK, response.Code)
 
-	// Get the data
-	var data GeoJSONFeatureCollection
-	err := json.Unmarshal(response.Body.Bytes(), &data)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if data.Type != "FeatureCollection" {
-		t.Error("Data is not a FeatureCollection.")
-	}
-
-	if len(data.Features) != 122 {
-		t.Error("Incorrect number of features returned.")
-	}
+	data := decodeResponse[GeoJSONFeatureCollection](t, response)
+	requireNonEmptyFeatureCollection(t, data)
 }

--- a/cmd/apiary/apb_test.go
+++ b/cmd/apiary/apb_test.go
@@ -21,8 +21,8 @@ func TestAPBFeaturedVerses(t *testing.T) {
 		t.Error(err)
 	}
 
-	if len(data) < 4 {
-		t.Error("Not enough verses returned.")
+	if len(data) == 0 {
+		t.Error("No featured verses returned.")
 	}
 
 }
@@ -40,8 +40,8 @@ func TestAPBTopVerses(t *testing.T) {
 		t.Error(err)
 	}
 
-	if len(data) < 100 {
-		t.Error("Not enough verses returned.")
+	if len(data) == 0 {
+		t.Error("No top verses returned.")
 	}
 
 }
@@ -59,8 +59,8 @@ func TestAPBVersePeaks(t *testing.T) {
 		t.Error(err)
 	}
 
-	if len(data) < 100 {
-		t.Error("Not enough verses returned.")
+	if len(data) == 0 {
+		t.Error("No verse peaks returned.")
 	}
 
 }
@@ -169,8 +169,8 @@ func TestAPBVerseQuotations(t *testing.T) {
 		t.Error(err)
 	}
 
-	if len(data) < 100 {
-		t.Error("Not enough verses returned.")
+	if len(data) == 0 {
+		t.Error("No verse quotations returned.")
 	}
 
 }

--- a/cmd/apiary/bom_test.go
+++ b/cmd/apiary/bom_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -22,25 +23,19 @@ func TestBomParishes(t *testing.T) {
 		t.Error(err)
 	}
 
-	// Check that the data has the right content
-	if len(data) < 2 {
-		t.Fatalf("expected at least two parishes, got %d", len(data))
+	if len(data) == 0 {
+		t.Fatal("expected BOM parishes")
 	}
-	expected := []struct {
-		id            int
-		name          string
-		canonicalName string
-	}{
-		{1, "Alhallows Barking", "All Hallows Barking"},
-		{2, "Alhallows Breadstreet", "All Hallows Bread Street"},
-	}
-	for i, want := range expected {
-		got := data[i]
-		if got.ParishID != want.id || got.Name != want.name || got.CanonicalName != want.canonicalName {
-			t.Errorf("parish %d = (%d, %q, %q), want (%d, %q, %q)",
-				i, got.ParishID, got.Name, got.CanonicalName,
-				want.id, want.name, want.canonicalName)
+
+	seenIDs := make(map[int]bool, len(data))
+	for index, parish := range data {
+		if parish.ParishID <= 0 || parish.Name == "" || parish.CanonicalName == "" {
+			t.Errorf("parish %d is missing identifying fields: %+v", index, parish)
 		}
+		if seenIDs[parish.ParishID] {
+			t.Errorf("parish ID %d appears more than once", parish.ParishID)
+		}
+		seenIDs[parish.ParishID] = true
 	}
 }
 
@@ -366,23 +361,44 @@ func TestIsValidCountType(t *testing.T) {
 
 func TestBomBillsInvalidParish(t *testing.T) {
 	// Unknown parish IDs return 400 naming the offending IDs.
-	req, _ := http.NewRequest("GET", "/bom/bills?start-year=1669&end-year=1754&parish=99999", nil)
+	req, _ := http.NewRequest(
+		"GET",
+		"/bom/bills?start-year=1669&end-year=1754&parish=2147483647",
+		nil,
+	)
 	response := executeRequest(req)
 	checkResponseCode(t, http.StatusBadRequest, response.Code)
-	if body := strings.TrimSpace(response.Body.String()); body != "invalid parish ID(s): 99999" {
+	if body := strings.TrimSpace(response.Body.String()); body != "invalid parish ID(s): 2147483647" {
 		t.Errorf("unexpected error body: %q", body)
 	}
 
 	// Multiple unknown IDs are all reported, comma-space separated, in request order.
-	req, _ = http.NewRequest("GET", "/bom/bills?start-year=1669&end-year=1754&parish=99998,99999", nil)
+	req, _ = http.NewRequest(
+		"GET",
+		"/bom/bills?start-year=1669&end-year=1754&parish=2147483646,2147483647",
+		nil,
+	)
 	response = executeRequest(req)
 	checkResponseCode(t, http.StatusBadRequest, response.Code)
-	if body := strings.TrimSpace(response.Body.String()); body != "invalid parish ID(s): 99998, 99999" {
+	if body := strings.TrimSpace(response.Body.String()); body != "invalid parish ID(s): 2147483646, 2147483647" {
 		t.Errorf("unexpected error body: %q", body)
 	}
 
-	// A valid parish ID still returns 200.
-	req, _ = http.NewRequest("GET", "/bom/bills?start-year=1669&end-year=1754&parish=1", nil)
+	// Select a valid parish ID from the database rather than assuming one.
+	parishRequest, _ := http.NewRequest(http.MethodGet, "/bom/parishes", nil)
+	parishResponse := executeRequest(parishRequest)
+	checkResponseCode(t, http.StatusOK, parishResponse.Code)
+	parishes := decodeResponse[[]apiary.Parish](t, parishResponse)
+	if len(parishes) == 0 {
+		t.Fatal("expected at least one parish")
+	}
+
+	req, _ = http.NewRequest(
+		"GET",
+		"/bom/bills?start-year=1669&end-year=1754&parish="+
+			strconv.Itoa(parishes[0].ParishID),
+		nil,
+	)
 	response = executeRequest(req)
 	checkResponseCode(t, http.StatusOK, response.Code)
 }

--- a/cmd/apiary/catholics_test.go
+++ b/cmd/apiary/catholics_test.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"encoding/json"
 	"net/http"
-	"reflect"
 	"testing"
 
 	apiary "github.com/chnm/apiary"
@@ -15,11 +13,14 @@ func TestCatholicDioceses(t *testing.T) {
 	response := executeRequest(req)
 	checkResponseCode(t, http.StatusOK, response.Code)
 
-	// Get the data
-	var data []apiary.CatholicDiocese
-	err := json.Unmarshal(response.Body.Bytes(), &data)
-	if err != nil {
-		t.Error(err)
+	data := decodeResponse[[]apiary.CatholicDiocese](t, response)
+	if len(data) == 0 {
+		t.Fatal("expected Catholic dioceses")
+	}
+	for index, diocese := range data {
+		if diocese.City == "" || diocese.Country == "" || diocese.Rite == "" {
+			t.Errorf("diocese %d is missing identifying fields: %+v", index, diocese)
+		}
 	}
 }
 
@@ -29,20 +30,26 @@ func TestCatholicDiocesesPerDecade(t *testing.T) {
 	response := executeRequest(req)
 	checkResponseCode(t, http.StatusOK, response.Code)
 
-	// Get the data
-	var data []apiary.CatholicDiocesesPerDecade
-	err := json.Unmarshal(response.Body.Bytes(), &data)
-	if err != nil {
-		t.Error(err)
+	data := decodeResponse[[]apiary.CatholicDiocesesPerDecade](t, response)
+	if len(data) == 0 {
+		t.Fatal("expected Catholic diocese decade statistics")
 	}
 
-	// Check that the data has the right content
-	expected := []apiary.CatholicDiocesesPerDecade{
-		{Decade: 1500, Count: 0},
-		{Decade: 1510, Count: 3},
-		{Decade: 1520, Count: 1},
-	}
-	if !reflect.DeepEqual(data[0:3], expected) {
-		t.Error("Values in data are not what was expected.")
+	for index, row := range data {
+		if row.Decade%10 != 0 {
+			t.Errorf("row %d has non-decade year %d", index, row.Decade)
+		}
+		if row.Count < 0 {
+			t.Errorf("row %d has negative count %d", index, row.Count)
+		}
+		if index > 0 && row.Decade != data[index-1].Decade+10 {
+			t.Errorf(
+				"decades are not consecutive at rows %d and %d: %d, %d",
+				index-1,
+				index,
+				data[index-1].Decade,
+				row.Decade,
+			)
+		}
 	}
 }

--- a/cmd/apiary/main_test.go
+++ b/cmd/apiary/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -18,6 +19,9 @@ type GeoJSONFeatureCollection struct {
 	Features []interface{} `json:"features"`
 }
 
+// The integration suite runs against the database configured by APIARY_DB.
+// Assertions should validate response contracts and stable invariants rather
+// than exact counts or records from mutable data.
 func TestMain(m *testing.M) {
 	os.Setenv("APIARY_LOGGING", "off") // No logs during testing
 	s = apiary.NewServer(context.TODO())
@@ -34,7 +38,32 @@ func executeRequest(req *http.Request) *httptest.ResponseRecorder {
 
 // Helper for tests.
 func checkResponseCode(t *testing.T, expected, actual int) {
+	t.Helper()
 	if expected != actual {
 		t.Errorf("Expected response code %d. Got %d.\n", expected, actual)
+	}
+}
+
+func decodeResponse[T any](t *testing.T, response *httptest.ResponseRecorder) T {
+	t.Helper()
+
+	var data T
+	if err := json.Unmarshal(response.Body.Bytes(), &data); err != nil {
+		t.Fatalf("decode response JSON: %v", err)
+	}
+	return data
+}
+
+func requireNonEmptyFeatureCollection(
+	t *testing.T,
+	data GeoJSONFeatureCollection,
+) {
+	t.Helper()
+
+	if data.Type != "FeatureCollection" {
+		t.Fatalf("GeoJSON type = %q, want FeatureCollection", data.Type)
+	}
+	if len(data.Features) == 0 {
+		t.Fatal("GeoJSON FeatureCollection is empty")
 	}
 }

--- a/cmd/apiary/ne_test.go
+++ b/cmd/apiary/ne_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"net/http"
 	"testing"
 )
@@ -11,20 +10,8 @@ func TestGlobe(t *testing.T) {
 	response := executeRequest(req)
 	checkResponseCode(t, http.StatusOK, response.Code)
 
-	// Get the data
-	var data GeoJSONFeatureCollection
-	err := json.Unmarshal(response.Body.Bytes(), &data)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if data.Type != "FeatureCollection" {
-		t.Error("Data is not a FeatureCollection.")
-	}
-
-	if len(data.Features) != 255 {
-		t.Error("Incorrect number of features returned. Got: ", len(data.Features), " Expected: 254")
-	}
+	data := decodeResponse[GeoJSONFeatureCollection](t, response)
+	requireNonEmptyFeatureCollection(t, data)
 }
 
 func TestNorthAmerica(t *testing.T) {
@@ -32,20 +19,8 @@ func TestNorthAmerica(t *testing.T) {
 	response := executeRequest(req)
 	checkResponseCode(t, http.StatusOK, response.Code)
 
-	// Get the data
-	var data GeoJSONFeatureCollection
-	err := json.Unmarshal(response.Body.Bytes(), &data)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if data.Type != "FeatureCollection" {
-		t.Error("Data is not a FeatureCollection.")
-	}
-
-	if len(data.Features) != 38 {
-		t.Error("Incorrect number of features returned. Got: ", len(data.Features), " Expected: 38")
-	}
+	data := decodeResponse[GeoJSONFeatureCollection](t, response)
+	requireNonEmptyFeatureCollection(t, data)
 }
 
 func TestAsia(t *testing.T) {
@@ -53,22 +28,6 @@ func TestAsia(t *testing.T) {
 	response := executeRequest(req)
 	checkResponseCode(t, http.StatusOK, response.Code)
 
-	// Get the data
-	var data GeoJSONFeatureCollection
-	err := json.Unmarshal(response.Body.Bytes(), &data)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if len(data.Features) == 0 {
-		t.Error("No features returned.")
-	}
-
-	if data.Type != "FeatureCollection" {
-		t.Error("Data is not a FeatureCollection.")
-	}
-
-	if len(data.Features) != 53 {
-		t.Error("Incorrect number of features returned. Got: ", len(data.Features), " Expected: 53")
-	}
+	data := decodeResponse[GeoJSONFeatureCollection](t, response)
+	requireNonEmptyFeatureCollection(t, data)
 }

--- a/cmd/apiary/pinkertons_test.go
+++ b/cmd/apiary/pinkertons_test.go
@@ -74,21 +74,29 @@ func TestDetectivesActivitiesDefaultLimit(t *testing.T) {
 	const defaultLimit = 500
 
 	defaultPage := fetchDetectiveActivities(t, "/pinkertons/activities")
-	if len(defaultPage) != defaultLimit {
-		t.Fatalf(
-			"Default page length = %d, want %d",
-			len(defaultPage),
-			defaultLimit,
-		)
-	}
-
 	explicitPage := fetchDetectiveActivities(
 		t,
 		"/pinkertons/activities?limit=501",
 	)
-	if len(explicitPage) != defaultLimit+1 {
+	if len(explicitPage) == 0 {
+		t.Fatal("No Pinkertons activities returned")
+	}
+
+	wantDefaultLength := len(explicitPage)
+	if wantDefaultLength > defaultLimit {
+		wantDefaultLength = defaultLimit
+	}
+	if len(defaultPage) != wantDefaultLength {
 		t.Fatalf(
-			"Explicit page length = %d, want %d",
+			"Default page length = %d, want %d",
+			len(defaultPage),
+			wantDefaultLength,
+		)
+	}
+
+	if len(explicitPage) > defaultLimit+1 {
+		t.Fatalf(
+			"Explicit page length = %d, want at most %d",
 			len(explicitPage),
 			defaultLimit+1,
 		)
@@ -137,8 +145,8 @@ func TestDetectivesActivitiesOffsetPagination(t *testing.T) {
 		t,
 		"/pinkertons/activities?limit=2&offset=0",
 	)
-	if len(firstTwo) != 2 {
-		t.Fatalf("First page length = %d, want 2", len(firstTwo))
+	if len(firstTwo) < 2 {
+		t.Skipf("Need at least two activities to test offset pagination; got %d", len(firstTwo))
 	}
 
 	secondActivity := fetchDetectiveActivities(
@@ -156,15 +164,19 @@ func TestDetectivesActivitiesOffsetPagination(t *testing.T) {
 		)
 	}
 
+	locationCandidates := fetchDetectiveActivities(
+		t,
+		"/pinkertons/activities?limit=50&offset=0",
+	)
 	var locationID int
-	for _, activity := range firstTwo {
+	for _, activity := range locationCandidates {
 		if len(activity.Locations) > 0 {
 			locationID = activity.Locations[0].ID
 			break
 		}
 	}
 	if locationID == 0 {
-		t.Fatal("First page has no location to test filtered pagination")
+		t.Skip("No activity location is available to test filtered pagination")
 	}
 
 	filteredPage := fetchDetectiveActivities(

--- a/cmd/apiary/pop_places_test.go
+++ b/cmd/apiary/pop_places_test.go
@@ -1,78 +1,102 @@
 package main
 
 import (
-	"encoding/json"
 	"net/http"
-	"reflect"
+	"strconv"
 	"testing"
 
 	apiary "github.com/chnm/apiary"
 )
 
 func TestCountiesInState(t *testing.T) {
-	req, _ := http.NewRequest("GET", "/pop-places/state/nc/county/", nil)
-	response := executeRequest(req)
-	checkResponseCode(t, http.StatusOK, response.Code)
-
-	// Get the data
-	var data []apiary.PlaceCounty
-	err := json.Unmarshal(response.Body.Bytes(), &data)
-	if err != nil {
-		t.Error(err)
+	data := fetchCountiesInState(t, "ma")
+	for index, county := range data {
+		if county.CountyAHCB == "" || county.County == "" {
+			t.Errorf("county %d is missing identifying fields: %+v", index, county)
+		}
+		if index > 0 && county.County < data[index-1].County {
+			t.Errorf(
+				"counties are not sorted at rows %d and %d: %q, %q",
+				index-1,
+				index,
+				data[index-1].County,
+				county.County,
+			)
+		}
 	}
-
-	// Check that the data has the right content
-	expected := []apiary.PlaceCounty{
-		{CountyAHCB: "ncs_alamance", County: "Alamance"},
-		{CountyAHCB: "ncs_alexander", County: "Alexander"},
-	}
-	if !reflect.DeepEqual(data[0:2], expected) {
-		t.Error("Values in data are not what was expected.")
-	}
-
 }
 
 func TestPlacesInCounty(t *testing.T) {
-	req, _ := http.NewRequest("GET", "/pop-places/county/mas_middlesex/place/", nil)
-	response := executeRequest(req)
-	checkResponseCode(t, http.StatusOK, response.Code)
-
-	// Get the data
-	var data []apiary.Place
-	err := json.Unmarshal(response.Body.Bytes(), &data)
-	if err != nil {
-		t.Error(err)
+	county := fetchCountiesInState(t, "ma")[0]
+	data := fetchPlacesInCounty(t, county.CountyAHCB)
+	for index, place := range data {
+		if place.PlaceID <= 0 || place.Place == "" {
+			t.Errorf("place %d is missing identifying fields: %+v", index, place)
+		}
 	}
 }
 
 func TestPlace(t *testing.T) {
-	req, _ := http.NewRequest("GET", "/pop-places/place/611119/", nil)
+	county := fetchCountiesInState(t, "ma")[0]
+	place := fetchPlacesInCounty(t, county.CountyAHCB)[0]
+	req, _ := http.NewRequest(
+		http.MethodGet,
+		"/pop-places/place/"+strconv.Itoa(place.PlaceID)+"/",
+		nil,
+	)
 	response := executeRequest(req)
 	checkResponseCode(t, http.StatusOK, response.Code)
 
-	// Get the data
-	var data apiary.PlaceDetails
-	err := json.Unmarshal(response.Body.Bytes(), &data)
-	if err != nil {
-		t.Error(err)
+	data := decodeResponse[apiary.PlaceDetails](t, response)
+	if data.PlaceID != place.PlaceID ||
+		data.Place != place.Place ||
+		data.MapName != place.MapName ||
+		data.CountyAHCB != county.CountyAHCB {
+		t.Fatalf(
+			"place details = %+v, want list record %+v in county %+v",
+			data,
+			place,
+			county,
+		)
 	}
-
-	expected := apiary.PlaceDetails{
-		PlaceID:    611119,
-		Place:      "Groton",
-		MapName:    "Ayer",
-		County:     "Middlesex",
-		CountyAHCB: "mas_middlesex",
-		State:      "MA",
-	}
-	if !reflect.DeepEqual(data, expected) {
-		t.Error("Values in data are not what was expected.")
-	}
-
 }
 
 func TestPlaceNotFound(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/pop-places/place/2147483647/", nil)
 	response := executeRequest(req)
 	checkResponseCode(t, http.StatusNotFound, response.Code)
+}
+
+func fetchCountiesInState(t *testing.T, state string) []apiary.PlaceCounty {
+	t.Helper()
+
+	request, _ := http.NewRequest(
+		http.MethodGet,
+		"/pop-places/state/"+state+"/county/",
+		nil,
+	)
+	response := executeRequest(request)
+	checkResponseCode(t, http.StatusOK, response.Code)
+	data := decodeResponse[[]apiary.PlaceCounty](t, response)
+	if len(data) == 0 {
+		t.Fatalf("expected populated-place counties for state %q", state)
+	}
+	return data
+}
+
+func fetchPlacesInCounty(t *testing.T, county string) []apiary.Place {
+	t.Helper()
+
+	request, _ := http.NewRequest(
+		http.MethodGet,
+		"/pop-places/county/"+county+"/place/",
+		nil,
+	)
+	response := executeRequest(request)
+	checkResponseCode(t, http.StatusOK, response.Code)
+	data := decodeResponse[[]apiary.Place](t, response)
+	if len(data) == 0 {
+		t.Fatalf("expected populated places for county %q", county)
+	}
+	return data
 }

--- a/cmd/apiary/presbyterians_test.go
+++ b/cmd/apiary/presbyterians_test.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"encoding/json"
 	"net/http"
-	"reflect"
 	"testing"
 
 	apiary "github.com/chnm/apiary"
@@ -15,19 +13,31 @@ func TestPresbyterians(t *testing.T) {
 	response := executeRequest(req)
 	checkResponseCode(t, http.StatusOK, response.Code)
 
-	// Get the data
-	var data []apiary.PresbyteriansByYear
-	err := json.Unmarshal(response.Body.Bytes(), &data)
-	if err != nil {
-		t.Error(err)
+	data := decodeResponse[[]apiary.PresbyteriansByYear](t, response)
+	if len(data) == 0 {
+		t.Fatal("expected Presbyterian statistics")
 	}
 
-	// Check that the data has the right content
-	expected := []apiary.PresbyteriansByYear{
-		{Year: 1826, Members: 127440, Churches: 1819},
-		{Year: 1827, Members: 135285, Churches: 1887}}
-	if !reflect.DeepEqual(data[0:2], expected) {
-		t.Error("Values in data are not what was expected.")
+	for index, row := range data {
+		if row.Year <= 0 {
+			t.Errorf("row %d has invalid year %d", index, row.Year)
+		}
+		if row.Members < 0 || row.Churches < 0 {
+			t.Errorf(
+				"row %d has negative totals: members=%d churches=%d",
+				index,
+				row.Members,
+				row.Churches,
+			)
+		}
+		if index > 0 && row.Year <= data[index-1].Year {
+			t.Errorf(
+				"years are not strictly increasing at rows %d and %d: %d, %d",
+				index-1,
+				index,
+				data[index-1].Year,
+				row.Year,
+			)
+		}
 	}
-
 }

--- a/cmd/apiary/relcensus_test.go
+++ b/cmd/apiary/relcensus_test.go
@@ -1,9 +1,8 @@
 package main
 
 import (
-	"encoding/json"
 	"net/http"
-	"reflect"
+	"net/url"
 	"testing"
 
 	apiary "github.com/chnm/apiary"
@@ -15,16 +14,10 @@ func TestRelCensusDenominations(t *testing.T) {
 	response := executeRequest(req)
 	checkResponseCode(t, http.StatusOK, response.Code)
 
-	// Get the data
-	var data []apiary.Denomination
-	err := json.Unmarshal(response.Body.Bytes(), &data)
-	if err != nil {
-		t.Error(err)
+	data := decodeResponse[[]apiary.Denomination](t, response)
+	if len(data) == 0 {
+		t.Fatal("expected Religious Census denominations")
 	}
-}
-
-type FamilyMap struct {
-	Param map[string]string `json:"family_relec"`
 }
 
 func TestRelCensusFamilies(t *testing.T) {
@@ -33,53 +26,104 @@ func TestRelCensusFamilies(t *testing.T) {
 	response := executeRequest(req)
 	checkResponseCode(t, http.StatusOK, response.Code)
 
-	// Get the data
-	// var data []apiary.DenominationFamily
-	data := struct {
+	data := decodeResponse[struct {
 		FamilyRelec []apiary.DenominationFamily `json:"family_relec"`
-	}{}
-	err := json.Unmarshal(response.Body.Bytes(), &data)
-	if err != nil {
-		t.Error(err)
+	}](t, response)
+	if len(data.FamilyRelec) == 0 {
+		t.Fatal("expected Religious Census denomination families")
 	}
 
-	// Check that the data has the right content
-	expected := []apiary.DenominationFamily{
-		{Name: "Adventist"},
-		{Name: "Anabaptist"},
-		{Name: "Baptist"},
+	for index, family := range data.FamilyRelec {
+		if family.Name == "" {
+			t.Errorf("family %d has an empty name", index)
+		}
+		if index > 0 && family.Name < data.FamilyRelec[index-1].Name {
+			t.Errorf(
+				"families are not sorted at rows %d and %d: %q, %q",
+				index-1,
+				index,
+				data.FamilyRelec[index-1].Name,
+				family.Name,
+			)
+		}
 	}
+}
 
-	if !reflect.DeepEqual(data.FamilyRelec[0:3], expected) {
-		t.Errorf("Expected %v, got %v", expected, data.FamilyRelec)
+func fetchRelCensusDenominations(t *testing.T) []apiary.Denomination {
+	t.Helper()
+
+	request, _ := http.NewRequest(http.MethodGet, "/relcensus/denominations", nil)
+	response := executeRequest(request)
+	checkResponseCode(t, http.StatusOK, response.Code)
+	data := decodeResponse[[]apiary.Denomination](t, response)
+	if len(data) == 0 {
+		t.Fatal("expected Religious Census denominations")
 	}
+	return data
+}
+
+func fetchRelCensusFamilies(t *testing.T) []apiary.DenominationFamily {
+	t.Helper()
+
+	request, _ := http.NewRequest(http.MethodGet, "/relcensus/denomination-families", nil)
+	response := executeRequest(request)
+	checkResponseCode(t, http.StatusOK, response.Code)
+	data := decodeResponse[struct {
+		FamilyRelec []apiary.DenominationFamily `json:"family_relec"`
+	}](t, response)
+	if len(data.FamilyRelec) == 0 {
+		t.Fatal("expected Religious Census denomination families")
+	}
+	return data.FamilyRelec
 }
 
 func TestRelCensusCityDenominations(t *testing.T) {
 	// Check that we get the right response
-	req, _ := http.NewRequest("GET", "/relcensus/city-membership?year=1926&denomination=Church+of+God+in+Christ", nil)
+	denomination := fetchRelCensusDenominations(t)[0].Name
+	req, _ := http.NewRequest(
+		http.MethodGet,
+		"/relcensus/city-membership?year=1926&denomination="+url.QueryEscape(denomination),
+		nil,
+	)
 	response := executeRequest(req)
 	checkResponseCode(t, http.StatusOK, response.Code)
 
-	// Get the data
-	var data []apiary.CityMembership
-	err := json.Unmarshal(response.Body.Bytes(), &data)
-	if err != nil {
-		t.Error(err)
+	data := decodeResponse[[]apiary.CityMembership](t, response)
+	for index, row := range data {
+		if row.Year != 1926 || row.Group != denomination {
+			t.Errorf(
+				"row %d = year %d group %q, want 1926 and %q",
+				index,
+				row.Year,
+				row.Group,
+				denomination,
+			)
+		}
 	}
 }
 
 func TestRelCensusCityFamilies(t *testing.T) {
 	// Check that we get the right response
-	req, _ := http.NewRequest("GET", "/relcensus/city-membership?year=1926&denominationFamily=Pentecostal", nil)
+	family := fetchRelCensusFamilies(t)[0].Name
+	req, _ := http.NewRequest(
+		http.MethodGet,
+		"/relcensus/city-membership?year=1926&denominationFamily="+url.QueryEscape(family),
+		nil,
+	)
 	response := executeRequest(req)
 	checkResponseCode(t, http.StatusOK, response.Code)
 
-	// Get the data
-	var data []apiary.CityMembership
-	err := json.Unmarshal(response.Body.Bytes(), &data)
-	if err != nil {
-		t.Error(err)
+	data := decodeResponse[[]apiary.CityMembership](t, response)
+	for index, row := range data {
+		if row.Year != 1926 || row.Group != family {
+			t.Errorf(
+				"row %d = year %d group %q, want 1926 and %q",
+				index,
+				row.Year,
+				row.Group,
+				family,
+			)
+		}
 	}
 }
 
@@ -89,11 +133,19 @@ func TestRelCensusCityAggregates(t *testing.T) {
 	response := executeRequest(req)
 	checkResponseCode(t, http.StatusOK, response.Code)
 
-	// Get the data
-	var data []apiary.CityMembership
-	err := json.Unmarshal(response.Body.Bytes(), &data)
-	if err != nil {
-		t.Error(err)
+	data := decodeResponse[[]apiary.CityMembership](t, response)
+	if len(data) == 0 {
+		t.Fatal("expected aggregated Religious Census city membership")
+	}
+	for index, row := range data {
+		if row.Year != 1926 || row.Group != "All denominations" {
+			t.Errorf(
+				"row %d = year %d group %q, want 1926 and All denominations",
+				index,
+				row.Year,
+				row.Group,
+			)
+		}
 	}
 }
 
@@ -102,10 +154,7 @@ func TestRelCensusLocations(t *testing.T) {
 	response := executeRequest(req)
 	checkResponseCode(t, http.StatusOK, response.Code)
 
-	var data []apiary.LocationInfo
-	if err := json.Unmarshal(response.Body.Bytes(), &data); err != nil {
-		t.Fatal(err)
-	}
+	data := decodeResponse[[]apiary.LocationInfo](t, response)
 	if len(data) == 0 {
 		t.Fatal("expected Religious Census locations")
 	}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -126,18 +127,98 @@ func Test_dateInRange(t *testing.T) {
 }
 
 func TestNullInt64(t *testing.T) {
-	emptyInt := NullInt64{sql.NullInt64{Int64: 0, Valid: false}}
-	out, _ := json.Marshal(emptyInt)
-	if string(out) != "null" {
-		t.Errorf("Want: null. Got: %s.", out)
+	tests := []struct {
+		name  string
+		value NullInt64
+		want  string
+	}{
+		{
+			name:  "valid",
+			value: NullInt64{NullInt64: sql.NullInt64{Int64: 42, Valid: true}},
+			want:  "42",
+		},
+		{
+			name:  "null",
+			value: NullInt64{NullInt64: sql.NullInt64{Valid: false}},
+			want:  "null",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := json.Marshal(tt.value)
+			if err != nil {
+				t.Fatalf("marshal NullInt64: %v", err)
+			}
+			if got := string(out); got != tt.want {
+				t.Fatalf("marshal NullInt64 = %s, want %s", got, tt.want)
+			}
+		})
+	}
+
+	var value NullInt64
+	if err := json.Unmarshal([]byte("27"), &value); err != nil {
+		t.Fatalf("unmarshal valid NullInt64: %v", err)
+	}
+	if !value.Valid || value.Int64 != 27 {
+		t.Fatalf("unmarshal valid NullInt64 = %+v, want 27 and valid", value)
+	}
+	if err := json.Unmarshal([]byte("null"), &value); err != nil {
+		t.Fatalf("unmarshal null NullInt64: %v", err)
+	}
+	if value.Valid {
+		t.Fatalf("unmarshal null NullInt64 = %+v, want invalid", value)
+	}
+	if err := json.Unmarshal([]byte(`"invalid"`), &value); err == nil {
+		t.Fatal("unmarshal invalid NullInt64 returned nil error")
 	}
 }
 
 func TestNullString(t *testing.T) {
-	emptyString := NullString{sql.NullString{String: "", Valid: false}}
-	out, _ := json.Marshal(emptyString)
-	if string(out) != "null" {
-		t.Errorf("Want: null. Got: %s.", out)
+	tests := []struct {
+		name  string
+		value NullString
+		want  string
+	}{
+		{
+			name:  "valid",
+			value: NullString{NullString: sql.NullString{String: "value", Valid: true}},
+			want:  `"value"`,
+		},
+		{
+			name:  "null",
+			value: NullString{NullString: sql.NullString{Valid: false}},
+			want:  "null",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := json.Marshal(tt.value)
+			if err != nil {
+				t.Fatalf("marshal NullString: %v", err)
+			}
+			if got := string(out); got != tt.want {
+				t.Fatalf("marshal NullString = %s, want %s", got, tt.want)
+			}
+		})
+	}
+
+	var value NullString
+	if err := json.Unmarshal([]byte(`"text"`), &value); err != nil {
+		t.Fatalf("unmarshal valid NullString: %v", err)
+	}
+	if !value.Valid || value.String != "text" {
+		t.Fatalf("unmarshal valid NullString = %+v, want text and valid", value)
+	}
+	if err := json.Unmarshal([]byte("null"), &value); err != nil {
+		t.Fatalf("unmarshal null NullString: %v", err)
+	}
+	if value.Valid {
+		t.Fatalf("unmarshal null NullString = %+v, want invalid", value)
+	}
+	if err := json.Unmarshal([]byte("42"), &value); err == nil {
+		t.Fatal("unmarshal invalid NullString returned nil error")
 	}
 }
 
@@ -147,5 +228,32 @@ func TestIntsToString(t *testing.T) {
 	}
 	if got := intsToString([]int{7}); got != "7" {
 		t.Errorf(`intsToString([7]) = %q, want "7"`, got)
+	}
+}
+
+func TestGetEnv(t *testing.T) {
+	const key = "APIARY_HELPERS_TEST_ENV"
+
+	original, existed := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("unset test environment variable: %v", err)
+	}
+	t.Cleanup(func() {
+		if existed {
+			_ = os.Setenv(key, original)
+			return
+		}
+		_ = os.Unsetenv(key)
+	})
+
+	if got := getEnv(key, "fallback"); got != "fallback" {
+		t.Fatalf("getEnv missing = %q, want fallback", got)
+	}
+
+	if err := os.Setenv(key, "configured"); err != nil {
+		t.Fatalf("set test environment variable: %v", err)
+	}
+	if got := getEnv(key, "fallback"); got != "configured" {
+		t.Fatalf("getEnv configured = %q, want configured", got)
 	}
 }

--- a/http_handlers_test.go
+++ b/http_handlers_test.go
@@ -1,0 +1,161 @@
+package apiary
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+)
+
+func TestCacheTestHandler(t *testing.T) {
+	handler := (&Server{}).CacheTest()
+	first := httptest.NewRecorder()
+	handler.ServeHTTP(first, httptest.NewRequest(http.MethodGet, "/cache", nil))
+
+	if first.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", first.Code, http.StatusOK)
+	}
+	if contentType := first.Header().Get("Content-Type"); contentType != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json", contentType)
+	}
+
+	var firstResponse struct {
+		Startup time.Time `json:"startup"`
+		Handler time.Time `json:"handler"`
+	}
+	if err := json.Unmarshal(first.Body.Bytes(), &firstResponse); err != nil {
+		t.Fatalf("unmarshal first cache response: %v", err)
+	}
+	if firstResponse.Startup.IsZero() || firstResponse.Handler.IsZero() {
+		t.Fatalf("cache response contains zero timestamps: %+v", firstResponse)
+	}
+
+	second := httptest.NewRecorder()
+	handler.ServeHTTP(second, httptest.NewRequest(http.MethodGet, "/cache", nil))
+	var secondResponse struct {
+		Startup time.Time `json:"startup"`
+		Handler time.Time `json:"handler"`
+	}
+	if err := json.Unmarshal(second.Body.Bytes(), &secondResponse); err != nil {
+		t.Fatalf("unmarshal second cache response: %v", err)
+	}
+	if !secondResponse.Startup.Equal(firstResponse.Startup) {
+		t.Fatalf(
+			"startup changed from %s to %s",
+			firstResponse.Startup,
+			secondResponse.Startup,
+		)
+	}
+}
+
+func TestEndpointsHandler(t *testing.T) {
+	tests := []struct {
+		name       string
+		requestURL string
+		tls        bool
+		wantPrefix string
+	}{
+		{
+			name:       "http",
+			requestURL: "http://data.example/",
+			wantPrefix: "http://data.example/",
+		},
+		{
+			name:       "https",
+			requestURL: "https://data.example/",
+			tls:        true,
+			wantPrefix: "https://data.example/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, tt.requestURL, nil)
+			if tt.tls {
+				request.TLS = &tls.ConnectionState{}
+			}
+			response := httptest.NewRecorder()
+
+			(&Server{}).EndpointsHandler().ServeHTTP(response, request)
+
+			if response.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d", response.Code, http.StatusOK)
+			}
+			var endpoints []Endpoint
+			if err := json.Unmarshal(response.Body.Bytes(), &endpoints); err != nil {
+				t.Fatalf("unmarshal endpoint index: %v", err)
+			}
+			if len(endpoints) == 0 {
+				t.Fatal("endpoint index is empty")
+			}
+			for _, endpoint := range endpoints {
+				if !strings.HasPrefix(endpoint.URL, tt.wantPrefix) {
+					t.Fatalf(
+						"endpoint URL %q does not start with %q",
+						endpoint.URL,
+						tt.wantPrefix,
+					)
+				}
+			}
+			if strings.Contains(response.Body.String(), `\u0026`) {
+				t.Fatal("endpoint index escaped query-string ampersands")
+			}
+		})
+	}
+}
+
+func TestCORSMiddleware(t *testing.T) {
+	handler := corsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	response := httptest.NewRecorder()
+
+	handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusNoContent)
+	}
+	if origin := response.Header().Get("Access-Control-Allow-Origin"); origin != "*" {
+		t.Fatalf("Access-Control-Allow-Origin = %q, want *", origin)
+	}
+}
+
+func TestRoutesRegistersHandlersAndNotFound(t *testing.T) {
+	server := &Server{Router: mux.NewRouter()}
+	server.Routes()
+
+	for _, path := range []string{
+		"/ahcb/counties/1844-05-08/",
+		"/apb/bible-books",
+		"/bom/parishes",
+		"/pinkertons/activities/1",
+		"/relcensus/cities",
+	} {
+		request := httptest.NewRequest(http.MethodGet, path, nil)
+		if matched := server.Router.Match(request, &mux.RouteMatch{}); !matched {
+			t.Errorf("GET route %q was not registered", path)
+		}
+	}
+
+	post := httptest.NewRequest(http.MethodPost, "/apb/bible-books", nil)
+	if matched := server.Router.Match(post, &mux.RouteMatch{}); matched {
+		t.Fatal("POST unexpectedly matched a GET/HEAD-only route")
+	}
+
+	response := httptest.NewRecorder()
+	server.Router.ServeHTTP(
+		response,
+		httptest.NewRequest(http.MethodGet, "/not-a-route", nil),
+	)
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("not-found status = %d, want %d", response.Code, http.StatusNotFound)
+	}
+	if body := strings.TrimSpace(response.Body.String()); body != "404 Not found." {
+		t.Fatalf("not-found body = %q, want %q", body, "404 Not found.")
+	}
+}

--- a/pinkertons_values_test.go
+++ b/pinkertons_values_test.go
@@ -1,0 +1,86 @@
+package apiary
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+)
+
+func TestNullFloat64JSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		value NullFloat64
+		want  string
+	}{
+		{name: "valid", value: NullFloat64{Float64: 1.25, Valid: true}, want: "1.25"},
+		{name: "null", value: NullFloat64{}, want: "null"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encoded, err := json.Marshal(tt.value)
+			if err != nil {
+				t.Fatalf("marshal NullFloat64: %v", err)
+			}
+			if got := string(encoded); got != tt.want {
+				t.Fatalf("marshal NullFloat64 = %s, want %s", got, tt.want)
+			}
+		})
+	}
+
+	var value NullFloat64
+	if err := json.Unmarshal([]byte("2.5"), &value); err != nil {
+		t.Fatalf("unmarshal valid NullFloat64: %v", err)
+	}
+	if !value.Valid || value.Float64 != 2.5 {
+		t.Fatalf("unmarshal valid NullFloat64 = %+v, want 2.5 and valid", value)
+	}
+	if err := json.Unmarshal([]byte("null"), &value); err != nil {
+		t.Fatalf("unmarshal null NullFloat64: %v", err)
+	}
+	if value.Valid {
+		t.Fatalf("unmarshal null NullFloat64 = %+v, want invalid", value)
+	}
+	if err := json.Unmarshal([]byte(`"invalid"`), &value); err == nil {
+		t.Fatal("unmarshal invalid NullFloat64 returned nil error")
+	}
+}
+
+func TestNullFloat64Scan(t *testing.T) {
+	tests := []struct {
+		name  string
+		input interface{}
+		want  float64
+		valid bool
+	}{
+		{name: "null", input: nil, valid: false},
+		{name: "float64", input: float64(1.5), want: 1.5, valid: true},
+		{name: "float32", input: float32(2.5), want: 2.5, valid: true},
+		{name: "int64", input: int64(3), want: 3, valid: true},
+		{name: "int", input: 4, want: 4, valid: true},
+		{name: "string", input: "5.5", want: 5.5, valid: true},
+		{name: "bytes", input: []byte("6.5"), want: 6.5, valid: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var value NullFloat64
+			if err := value.Scan(tt.input); err != nil {
+				t.Fatalf("Scan(%v): %v", tt.input, err)
+			}
+			if value.Valid != tt.valid {
+				t.Fatalf("Valid = %t, want %t", value.Valid, tt.valid)
+			}
+			if math.Abs(value.Float64-tt.want) > 0.000001 {
+				t.Fatalf("Float64 = %f, want %f", value.Float64, tt.want)
+			}
+		})
+	}
+
+	for _, input := range []interface{}{"invalid", []byte("invalid"), true} {
+		var value NullFloat64
+		if err := value.Scan(input); err == nil {
+			t.Fatalf("Scan(%v) returned nil error", input)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- replace live-database snapshots and exact row-count assumptions with stable API-contract assertions
- select database-backed detail fixtures dynamically instead of relying on hard-coded records
- add deterministic unit coverage for BOM query construction, pagination, HTTP handlers, JSON helpers, and nullable Pinkertons values
- document the root, live-database, and Docker-backed test suites

Root package coverage increases from 41.7% to 53.7%.

This PR does not change CI workflow topology or introduce coverage thresholds. That infrastructure work remains sysadmin-owned in #121.

## Verification

- `go test -cover . -count=1` — 53.7%
- `go test ./cmd/apiary -count=1` with `APIARY_DB` — passed in 80.061s
- `go test -race . -count=1`
- `go test ./internal/lifecycle -count=1`
- `go test -run '^$' ./db`
- `go build ./...`
- `go vet ./...`
- `go mod tidy -diff`
- `staticcheck ./...`
- `govulncheck ./...` — no known vulnerabilities
- `gosec -quiet -exclude-dir=.claude ./...`
- `actionlint -color`
- `git diff --check`

Refs #100
