### PR TITLE
Revise populated places endpoints

### DIFF
--- a/cmd/apiary/pop_places_test.go
+++ b/cmd/apiary/pop_places_test.go
@@ -30,7 +30,7 @@ func TestPlacesInCounty(t *testing.T) {
 	county := fetchCountiesInState(t, "ma")[0]
 	data := fetchPlacesInCounty(t, county.CountyAHCB)
 	for index, place := range data {
-		if place.PlaceID <= 0 || place.Place == "" {
+		if place.PlaceID <= 0 || place.Place == "" || place.Lat == 0 || place.Lon == 0 {
 			t.Errorf("place %d is missing identifying fields: %+v", index, place)
 		}
 	}
@@ -50,7 +50,8 @@ func TestPlace(t *testing.T) {
 	data := decodeResponse[apiary.PlaceDetails](t, response)
 	if data.PlaceID != place.PlaceID ||
 		data.Place != place.Place ||
-		data.MapName != place.MapName ||
+		data.Lat != place.Lat ||
+		data.Lon != place.Lon ||
 		data.CountyAHCB != county.CountyAHCB {
 		t.Fatalf(
 			"place details = %+v, want list record %+v in county %+v",

--- a/populated-places.go
+++ b/populated-places.go
@@ -22,21 +22,23 @@ type PlaceCounty struct {
 	County     string `json:"name"`
 }
 
-// Place represents a place with ID and name
+// Place represents a populated place with its ID, name, and coordinates.
 type Place struct {
-	PlaceID int    `json:"place_id"`
-	Place   string `json:"place"`
-	MapName string `json:"map_name"`
+	PlaceID int     `json:"place_id"`
+	Place   string  `json:"place"`
+	Lat     float64 `json:"lat"`
+	Lon     float64 `json:"lon"`
 }
 
-// PlaceDetails represents details about a place
+// PlaceDetails represents details about a populated place.
 type PlaceDetails struct {
-	PlaceID    int    `json:"place_id"`
-	Place      string `json:"place"`
-	MapName    string `json:"map_name"`
-	County     string `json:"county"`
-	CountyAHCB string `json:"county_ahcb"`
-	State      string `json:"state"`
+	PlaceID    int     `json:"place_id"`
+	Place      string  `json:"place"`
+	Lat        float64 `json:"lat"`
+	Lon        float64 `json:"lon"`
+	County     string  `json:"county"`
+	CountyAHCB string  `json:"county_ahcb"`
+	State      string  `json:"state"`
 }
 
 // CountiesInState returns a list of all the counties in a state, with
@@ -98,7 +100,7 @@ func (s *Server) CountiesInState() http.HandlerFunc {
 func (s *Server) PlacesInCounty() http.HandlerFunc {
 
 	query := `
-		SELECT place_id, place, map_name
+		SELECT place_id, place, lat, lon
 		FROM relcensus.popplaces_1926
 		WHERE county_ahcb = $1
 		ORDER BY place;
@@ -121,7 +123,7 @@ func (s *Server) PlacesInCounty() http.HandlerFunc {
 
 		for rows.Next() {
 			var row Place
-			if err := rows.Scan(&row.PlaceID, &row.Place, &row.MapName); err != nil {
+			if err := rows.Scan(&row.PlaceID, &row.Place, &row.Lat, &row.Lon); err != nil {
 				log.Printf("scan populated place: %v", err)
 				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 				return
@@ -152,7 +154,7 @@ func (s *Server) PlacesInCounty() http.HandlerFunc {
 func (s *Server) Place() http.HandlerFunc {
 
 	query := `
-		SELECT place_id, place, map_name, county, county_ahcb, state
+		SELECT place_id, place, lat, lon, county, county_ahcb, state
 		FROM relcensus.popplaces_1926
 		WHERE place_id = $1
 		`
@@ -168,7 +170,7 @@ func (s *Server) Place() http.HandlerFunc {
 		var result PlaceDetails
 
 		err = s.DB.QueryRow(r.Context(), query, placeID).Scan(&result.PlaceID, &result.Place,
-			&result.MapName, &result.County, &result.CountyAHCB, &result.State)
+			&result.Lat, &result.Lon, &result.County, &result.CountyAHCB, &result.State)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				http.Error(w, fmt.Sprintf("Not found: No place with id %v.", placeID), http.StatusNotFound)

--- a/populated_places_test.go
+++ b/populated_places_test.go
@@ -1,0 +1,58 @@
+package apiary
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestPopulatedPlaceJSONContract(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+	}{
+		{
+			name: "county place",
+			value: Place{
+				PlaceID: 611119,
+				Place:   "Groton",
+				Lat:     42.6112,
+				Lon:     -71.5745,
+			},
+		},
+		{
+			name: "place details",
+			value: PlaceDetails{
+				PlaceID:    611119,
+				Place:      "Groton",
+				Lat:        42.6112,
+				Lon:        -71.5745,
+				County:     "Middlesex",
+				CountyAHCB: "mas_middlesex",
+				State:      "MA",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encoded, err := json.Marshal(tt.value)
+			if err != nil {
+				t.Fatalf("marshal populated place: %v", err)
+			}
+
+			var fields map[string]any
+			if err := json.Unmarshal(encoded, &fields); err != nil {
+				t.Fatalf("unmarshal populated place: %v", err)
+			}
+			if _, ok := fields["map_name"]; ok {
+				t.Fatalf("populated place contains removed map_name field: %s", encoded)
+			}
+			if got := fields["lat"]; got != 42.6112 {
+				t.Errorf("lat = %v, want 42.6112", got)
+			}
+			if got := fields["lon"]; got != -71.5745 {
+				t.Errorf("lon = %v, want -71.5745", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- remove the misleading map_name field from populated-place list and detail responses
- add latitude and longitude to both populated-place response shapes
- add JSON contract and database-backed regression coverage

Fixes #123