### PR TITLE
Validate BOM bill sort parameters

### DIFF
--- a/bom-bills.go
+++ b/bom-bills.go
@@ -65,6 +65,14 @@ type QueryOptions struct {
 	Offset int
 }
 
+const defaultBillsSort = "year"
+
+var billsSortExpressions = map[string]string{
+	"year":           "b.year, w.week_number, p.canonical_name",
+	"week_number":    "w.week_number, b.year, p.canonical_name",
+	"canonical_name": "p.canonical_name, b.year, w.week_number",
+}
+
 // QueryBuilder holds the query string and parameters
 type QueryBuilder struct {
 	Query  string
@@ -213,7 +221,7 @@ func parseAPIParameters(r *http.Request) (APIParameters, error) {
 		StartYear: 1648, // Default values
 		EndYear:   1750,
 		Parish:    []int{},
-		Sort:      "year, week_number, canonical_name",
+		Sort:      defaultBillsSort,
 	}
 
 	// Parse start year
@@ -332,6 +340,9 @@ func parseAPIParameters(r *http.Request) (APIParameters, error) {
 
 	// Parse sorting
 	if sort := r.URL.Query().Get("sort"); sort != "" {
+		if _, ok := billsSortExpressions[sort]; !ok {
+			return params, fmt.Errorf("invalid sort: supported values are year, week_number, and canonical_name")
+		}
 		params.Sort = sort
 	}
 
@@ -481,12 +492,17 @@ func buildBillsQueryWithParams(params APIParameters) (*QueryBuilder, error) {
 		baseQuery += " AND " + strings.Join(conditions, " AND ")
 	}
 
-	// Add sorting (ensure consistent ordering for cursor pagination)
-	if params.Sort != "" {
-		baseQuery += " ORDER BY " + params.Sort + " ASC"
-	} else {
-		baseQuery += " ORDER BY b.year, w.week_number, p.canonical_name ASC"
+	// Cursor pagination depends on the same ordering as its year/week/name
+	// continuation tuple. Other pagination modes may select a supported order.
+	sort := params.Sort
+	if sort == "" || params.Cursor != "" {
+		sort = defaultBillsSort
 	}
+	sortExpression, ok := billsSortExpressions[sort]
+	if !ok {
+		return nil, fmt.Errorf("unsupported bills sort %q", sort)
+	}
+	baseQuery += " ORDER BY " + sortExpression + " ASC"
 
 	// Handle pagination - cursor-based is the default and preferred method
 	if params.Cursor != "" {

--- a/bom-bills_test.go
+++ b/bom-bills_test.go
@@ -23,6 +23,23 @@ func TestTotalBillsHandlerRejectsInvalidType(t *testing.T) {
 	}
 }
 
+func TestBillsHandlerRejectsInvalidSort(t *testing.T) {
+	request := httptest.NewRequest(http.MethodGet, "/bom/bills", nil)
+	query := request.URL.Query()
+	query.Set("sort", "year; select pg_sleep(10)")
+	request.URL.RawQuery = query.Encode()
+	response := httptest.NewRecorder()
+
+	(&Server{}).BillsHandler().ServeHTTP(response, request)
+
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusBadRequest)
+	}
+	if body := strings.TrimSpace(response.Body.String()); body != "invalid sort: supported values are year, week_number, and canonical_name" {
+		t.Fatalf("body = %q, want fixed invalid sort error", body)
+	}
+}
+
 func TestParseAPIParametersParish(t *testing.T) {
 	// Non-integer parish IDs are rejected by the parser.
 	r := httptest.NewRequest("GET", "/bom/bills?parish=abc", nil)
@@ -208,6 +225,48 @@ func TestParseAPIParameters(t *testing.T) {
 	}
 }
 
+func TestParseAPIParametersSort(t *testing.T) {
+	tests := []struct {
+		name    string
+		sort    string
+		want    string
+		wantErr bool
+	}{
+		{name: "default", want: defaultBillsSort},
+		{name: "year", sort: "year", want: "year"},
+		{name: "week number", sort: "week_number", want: "week_number"},
+		{name: "canonical name", sort: "canonical_name", want: "canonical_name"},
+		{name: "SQL expression", sort: "lower(canonical_name)", wantErr: true},
+		{name: "stacked statement", sort: "year; select pg_sleep(10)", wantErr: true},
+		{name: "unsupported direction", sort: "year desc", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, "/bom/bills", nil)
+			query := request.URL.Query()
+			if tt.sort != "" {
+				query.Set("sort", tt.sort)
+				request.URL.RawQuery = query.Encode()
+			}
+
+			params, err := parseAPIParameters(request)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("parseAPIParameters returned nil error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseAPIParameters: %v", err)
+			}
+			if params.Sort != tt.want {
+				t.Fatalf("sort = %q, want %q", params.Sort, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseAPIParametersRejectsMalformedValues(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -294,6 +353,70 @@ func TestBuildBillsQueryPaginationModes(t *testing.T) {
 			}
 			if !reflect.DeepEqual(query.Params, tt.wantParams) {
 				t.Fatalf("params = %#v, want %#v", query.Params, tt.wantParams)
+			}
+		})
+	}
+}
+
+func TestBuildBillsQuerySorts(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  APIParameters
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "default",
+			params: APIParameters{},
+			want:   "ORDER BY b.year, w.week_number, p.canonical_name ASC",
+		},
+		{
+			name:   "year",
+			params: APIParameters{Sort: "year"},
+			want:   "ORDER BY b.year, w.week_number, p.canonical_name ASC",
+		},
+		{
+			name:   "week number",
+			params: APIParameters{Sort: "week_number"},
+			want:   "ORDER BY w.week_number, b.year, p.canonical_name ASC",
+		},
+		{
+			name:   "canonical name",
+			params: APIParameters{Sort: "canonical_name"},
+			want:   "ORDER BY p.canonical_name, b.year, w.week_number ASC",
+		},
+		{
+			name: "cursor retains continuation order",
+			params: APIParameters{
+				Sort:       "canonical_name",
+				Cursor:     "cursor",
+				CursorYear: 1665,
+				CursorWeek: 12,
+				CursorName: "All Hallows",
+			},
+			want: "ORDER BY b.year, w.week_number, p.canonical_name ASC",
+		},
+		{
+			name:    "rejects unvalidated caller",
+			params:  APIParameters{Sort: "year; select pg_sleep(10)"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query, err := buildBillsQueryWithParams(tt.params)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("buildBillsQueryWithParams returned nil error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("buildBillsQueryWithParams: %v", err)
+			}
+			if !strings.Contains(query.Query, tt.want) {
+				t.Fatalf("query does not contain %q", tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- validate the BOM bills `sort` parameter against the supported `year`, `week_number`, and `canonical_name` values
- map public values to fixed SQL ordering expressions and retain the year/week/name cursor order
- reject unsupported values before database work and defend the query builder against unvalidated callers
- replace pass-through expectations with parser, handler, query-builder, and malicious-input regression coverage

## Validation

- `go test .`
- `go test -race .`
- `go build ./...`
- `go vet ./...`
- `go mod verify`
- `go mod tidy -diff`
- `go test -run '^$' ./db`
- `gosec ./...`
- `git diff --check`

Closes #125